### PR TITLE
feat: migrate to ghcr.io and bump Tailscale to v1.96.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
 ARCHES := x86 arm
 # overrides to s9pk.mk must precede the include statement
 include s9pk.mk
+
+.PHONY: check-version
+check-version:
+	@bash scripts/check-version.sh
+
+arches: check-version

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ expose other StartOS services to your tailnet via `tailscale serve`.
 
 | Property      | Value                              |
 | ------------- | ---------------------------------- |
-| Image         | `tailscale/tailscale:stable`       |
+| Image         | `ghcr.io/tailscale/tailscale:v1.96.5` |
 | Architectures | x86_64, aarch64                    |
 | Runtime       | Two daemons in one subcontainer    |
 
@@ -212,7 +212,7 @@ None. Tailscale is a standalone service.
 4. **HTTPS reverse proxy for HTTP services** — `tailscale serve --bg --https`
    is used for HTTP backends; Tailscale terminates TLS so clients access
    services over `https://`. Non-HTTP services use raw TCP forwarding.
-5. **Web UI requires Tailscale v1.56.0+** — the `tailscale/tailscale:stable`
+5. **Web UI requires Tailscale v1.56.0+** — the `ghcr.io/tailscale/tailscale:v1.96.5`
    image satisfies this requirement.
 
 ---
@@ -240,7 +240,7 @@ workflow.
 
 ```yaml
 package_id: tailscale
-image: tailscale/tailscale:stable
+image: ghcr.io/tailscale/tailscale:v1.96.5
 architectures: [x86_64, aarch64]
 volumes:
   tailscale: /var/lib/tailscale       # daemon state

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# bump-version.sh — Upgrade the package to a new Tailscale release.
+# Usage: scripts/bump-version.sh <X.Y.Z>
+set -euo pipefail
+
+MANIFEST="startos/manifest/index.ts"
+VERSIONS_DIR="startos/versions"
+VERSIONS_INDEX="${VERSIONS_DIR}/index.ts"
+IMAGE="tailscale/tailscale"
+
+# ── Argument validation ───────────────────────────────────────────────────────
+NEW_VERSION="${1:-}"
+if [[ -z "$NEW_VERSION" ]]; then
+  echo "Usage: $0 <X.Y.Z>" >&2
+  exit 1
+fi
+if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "ERROR: Version must match X.Y.Z format (got: '$NEW_VERSION')" >&2
+  exit 1
+fi
+
+# ── Verify image exists on ghcr.io ───────────────────────────────────────────
+TOKEN=$(curl -fsSL \
+  "https://ghcr.io/token?scope=repository:${IMAGE}:pull&service=ghcr.io" \
+  | jq -r '.token')
+
+HTTP_STATUS=$(curl -o /dev/null -w "%{http_code}" -fsSI \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Accept: application/vnd.oci.image.index.v1+json" \
+  "https://ghcr.io/v2/${IMAGE}/manifests/v${NEW_VERSION}" 2>/dev/null || echo "000")
+
+if [[ "$HTTP_STATUS" != "200" ]]; then
+  echo "ERROR: ghcr.io/${IMAGE}:v${NEW_VERSION} not found (HTTP ${HTTP_STATUS})." >&2
+  echo "       Check that the version tag exists on ghcr.io." >&2
+  exit 1
+fi
+
+# ── Check current pinned version ─────────────────────────────────────────────
+PINNED_TAG=$(grep -oP "(?<=dockerTag: ')[^']+" "$MANIFEST")
+CURRENT_VERSION="${PINNED_TAG#ghcr.io/tailscale/tailscale:v}"
+
+if [[ "$CURRENT_VERSION" == "$NEW_VERSION" ]]; then
+  echo "Already at v${NEW_VERSION} — nothing to do."
+  exit 0
+fi
+
+# ── Derive variable names ─────────────────────────────────────────────────────
+var_name() {
+  local v="$1"
+  echo "v_$(echo "$v" | tr '.' '_')_0"
+}
+
+NEW_VAR=$(var_name "$NEW_VERSION")
+OLD_VAR=$(var_name "$CURRENT_VERSION")
+
+# ── Create new version file ───────────────────────────────────────────────────
+NEW_FILE="${VERSIONS_DIR}/v${NEW_VERSION}.0.ts"
+cat > "$NEW_FILE" <<TSEOF
+import { VersionInfo } from '@start9labs/start-sdk'
+
+export const ${NEW_VAR} = VersionInfo.of({
+  version: '${NEW_VERSION}:0',
+  releaseNotes: {
+    en_US: 'Upstream release — update this before publishing.',
+  },
+  migrations: {
+    up: async ({ effects }) => {},
+    down: async ({ effects }) => {},
+  },
+})
+TSEOF
+
+# ── Update manifest: replace dockerTag ───────────────────────────────────────
+sed -i "s|ghcr.io/tailscale/tailscale:v${CURRENT_VERSION}|ghcr.io/tailscale/tailscale:v${NEW_VERSION}|g" "$MANIFEST"
+
+# ── Update versions/index.ts ─────────────────────────────────────────────────
+# Build the new index file programmatically to avoid fragile multi-line sed
+python3 - "$VERSIONS_INDEX" "$NEW_VERSION" "$NEW_VAR" "$CURRENT_VERSION" "$OLD_VAR" <<'PYEOF'
+import sys, re
+
+index_file, new_ver, new_var, old_ver, old_var = sys.argv[1:]
+
+with open(index_file) as f:
+    content = f.read()
+
+# Collect existing imports (lines starting with "import")
+lines = content.splitlines()
+import_lines = [l for l in lines if l.startswith("import")]
+
+# Parse existing `other` array entries (variable names inside brackets)
+other_match = re.search(r'other:\s*\[([^\]]*)\]', content, re.DOTALL)
+existing_others = []
+if other_match:
+    raw = other_match.group(1)
+    existing_others = [t.strip() for t in raw.split(',') if t.strip()]
+
+# Add the old current to others if not already present
+if old_var not in existing_others:
+    existing_others.append(old_var)
+
+# Remove new_var from others if it crept in
+existing_others = [o for o in existing_others if o != new_var]
+
+# Gather all version files to derive all needed imports
+import_map = {}
+for line in import_lines:
+    m = re.search(r"import \{ (\w+) \} from '([^']+)'", line)
+    if m:
+        import_map[m.group(1)] = m.group(2)
+
+# Ensure new var import exists
+if new_var not in import_map:
+    import_map[new_var] = f'./{new_ver}.0'
+# Ensure old var import exists
+if old_var not in import_map:
+    import_map[old_var] = f'./{old_ver}.0'
+
+# Build output
+out_lines = ["import { VersionGraph } from '@start9labs/start-sdk'"]
+for var, path in sorted(import_map.items(), key=lambda x: x[1]):
+    if var != 'VersionGraph':
+        out_lines.append(f"import {{ {var} }} from '{path}'")
+
+others_str = ', '.join(existing_others) if existing_others else ''
+out_lines.append('')
+out_lines.append('export const versionGraph = VersionGraph.of({')
+out_lines.append(f'  current: {new_var},')
+out_lines.append(f'  other: [{others_str}],')
+out_lines.append('})')
+out_lines.append('')
+
+with open(index_file, 'w') as f:
+    f.write('\n'.join(out_lines))
+
+print("Updated", index_file)
+PYEOF
+
+# ── Print checklist ───────────────────────────────────────────────────────────
+cat <<EOF
+
+Bumped to v${NEW_VERSION}.
+
+Next steps:
+  1. Edit ${NEW_FILE}  — update release notes
+  2. Edit README.md                     — update version references
+  3. Run: make                          — to verify the build
+  4. Commit: feat: bump tailscale to v${NEW_VERSION}
+EOF

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# check-version.sh — Verify that the pinned Tailscale image matches ghcr.io stable.
+# Exits 1 with a human-readable error if stable has moved ahead of the pinned tag.
+# Set SKIP_VERSION_CHECK=1 to bypass.
+set -euo pipefail
+
+MANIFEST="startos/manifest/index.ts"
+REGISTRY="ghcr.io"
+IMAGE="tailscale/tailscale"
+
+if [[ "${SKIP_VERSION_CHECK:-}" == "1" ]]; then
+  echo "WARNING: SKIP_VERSION_CHECK=1 — skipping Tailscale version check." >&2
+  exit 0
+fi
+
+# Parse pinned version from manifest (e.g. ghcr.io/tailscale/tailscale:v1.96.5 → 1.96.5)
+PINNED_TAG=$(grep -oP "(?<=dockerTag: ')[^']+" "$MANIFEST")
+PINNED_VERSION="${PINNED_TAG#ghcr.io/tailscale/tailscale:v}"
+
+if [[ -z "$PINNED_VERSION" ]]; then
+  echo "ERROR: Could not parse pinned version from $MANIFEST" >&2
+  exit 1
+fi
+
+# Obtain an anonymous bearer token for ghcr.io
+TOKEN=$(curl -fsSL \
+  "https://ghcr.io/token?scope=repository:${IMAGE}:pull&service=ghcr.io" \
+  | jq -r '.token')
+
+fetch_digest() {
+  local tag="$1"
+  curl -fsSI \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Accept: application/vnd.oci.image.index.v1+json" \
+    "https://ghcr.io/v2/${IMAGE}/manifests/${tag}" \
+    | grep -i '^docker-content-digest:' \
+    | tr -d '[:space:]' \
+    | cut -d: -f2-
+}
+
+STABLE_DIGEST=$(fetch_digest "stable")
+PINNED_DIGEST=$(fetch_digest "v${PINNED_VERSION}")
+
+if [[ "$STABLE_DIGEST" == "$PINNED_DIGEST" ]]; then
+  echo "OK: ghcr.io/${IMAGE}:v${PINNED_VERSION} matches stable"
+  exit 0
+fi
+
+# Resolve the human-readable version for the stable digest by listing tags
+STABLE_VERSION=$(curl -fsSL \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "https://ghcr.io/v2/${IMAGE}/tags/list" \
+  | jq -r --arg digest "$STABLE_DIGEST" '
+      .tags[]
+      | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))
+    ' \
+  | while read -r tag; do
+      d=$(fetch_digest "$tag")
+      if [[ "$d" == "$STABLE_DIGEST" ]]; then
+        echo "${tag#v}"
+        break
+      fi
+    done)
+
+STABLE_VERSION="${STABLE_VERSION:-unknown}"
+
+cat >&2 <<EOF
+ERROR: ghcr.io/${IMAGE}:stable has moved to a newer version.
+
+  Pinned : v${PINNED_VERSION}
+  Stable : v${STABLE_VERSION}
+
+To upgrade  : run  scripts/bump-version.sh ${STABLE_VERSION}
+To stay put : run  SKIP_VERSION_CHECK=1 make
+EOF
+exit 1

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   volumes: ['tailscale', 'startos'],
   images: {
     tailscale: {
-      source: { dockerTag: 'tailscale/tailscale:stable' },
+      source: { dockerTag: 'ghcr.io/tailscale/tailscale:v1.96.5' },
       arch: ['x86_64', 'aarch64'],
     },
   },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,8 @@
 import { VersionGraph } from '@start9labs/start-sdk'
 import { v_1_96_4_0 } from './v1.96.4.0'
+import { v_1_96_5_0 } from './v1.96.5.0'
 
 export const versionGraph = VersionGraph.of({
-  current: v_1_96_4_0,
-  other: [],
+  current: v_1_96_5_0,
+  other: [v_1_96_4_0],
 })

--- a/startos/versions/v1.96.5.0.ts
+++ b/startos/versions/v1.96.5.0.ts
@@ -1,0 +1,12 @@
+import { VersionInfo } from '@start9labs/start-sdk'
+
+export const v_1_96_5_0 = VersionInfo.of({
+  version: '1.96.5:0',
+  releaseNotes: {
+    en_US: 'Updated to Tailscale v1.96.5. Migrated image source to ghcr.io.',
+  },
+  migrations: {
+    up: async ({ effects }) => {},
+    down: async ({ effects }) => {},
+  },
+})


### PR DESCRIPTION
## Summary

- Switches the image source from `tailscale/tailscale:stable` (Docker Hub) to `ghcr.io/tailscale/tailscale:v1.96.5` for reproducible, registry-independent builds
- Advances the version graph to `1.96.5:0` with a proper migration entry
- Adds `scripts/check-version.sh` — runs at build time and fails if `ghcr.io stable` has moved ahead of the pinned tag (bypassable with `SKIP_VERSION_CHECK=1 make`)
- Adds `scripts/bump-version.sh` — developer helper to upgrade to a new Tailscale release in one command
- Wires `check-version` as a prerequisite of the `arches` make target so it runs automatically on every build
- Updates all README image references (3 occurrences)

## Testing

```bash
# Verify no old image refs remain
grep -r "tailscale/tailscale:stable" .

# Version check passes (pinned == stable right now)
bash scripts/check-version.sh

# Dry-run bump helper
bash scripts/bump-version.sh --help 2>&1 || true
```