### PR TITLE
feat: support StarOS self-target in addServe

### DIFF
--- a/startos/actions/addServe.ts
+++ b/startos/actions/addServe.ts
@@ -43,13 +43,6 @@ export const addServe = sdk.Action.withInput(
       input.urlPluginMetadata
     const packageId = rawPkgId ?? 'startos'
 
-    // StartOS self-target is not supported: the node is already on the
-    // tailnet by IP, and the platform has no :443 binding registered.
-    if (packageId === 'startos') {
-      console.warn('[addServe] ignoring startos self-target — not supported')
-      return
-    }
-
     // Use .once() to avoid "write after const" error
     const store: z.infer<typeof shape> =
       (await storeJson.read().once()) || {}
@@ -61,26 +54,33 @@ export const addServe = sdk.Action.withInput(
       return
     }
 
-    // Resolve scheme from the service interface
+    // Resolve scheme and internal port from the service interface.
+    // StarOS itself has no registered service interface; its UI is always
+    // reachable at http://startos:80 inside the container network.
     let scheme: string | null
     let resolvedInternalPort: number
 
-    const iface = await sdk.serviceInterface
-      .get(effects, { id: interfaceId, packageId })
-      .once()
+    if (packageId === 'startos') {
+      scheme = 'http'
+      resolvedInternalPort = 80
+    } else {
+      const iface = await sdk.serviceInterface
+        .get(effects, { id: interfaceId, packageId })
+        .once()
 
-    console.info(
-      `[addServe] ${packageId}/${interfaceId} iface:`,
-      JSON.stringify({
-        type: iface?.type,
-        scheme: iface?.addressInfo?.scheme,
-        sslScheme: iface?.addressInfo?.sslScheme,
-        internalPort: iface?.addressInfo?.internalPort,
-      }),
-    )
+      console.info(
+        `[addServe] ${packageId}/${interfaceId} iface:`,
+        JSON.stringify({
+          type: iface?.type,
+          scheme: iface?.addressInfo?.scheme,
+          sslScheme: iface?.addressInfo?.sslScheme,
+          internalPort: iface?.addressInfo?.internalPort,
+        }),
+      )
 
-    scheme = iface?.addressInfo?.scheme ?? null
-    resolvedInternalPort = iface?.addressInfo?.internalPort ?? internalPort
+      scheme = iface?.addressInfo?.scheme ?? null
+      resolvedInternalPort = iface?.addressInfo?.internalPort ?? internalPort
+    }
 
     console.info(
       `[addServe] ${packageId}/${interfaceId} resolved → scheme=${scheme}, internalPort=${resolvedInternalPort}, tailnetPort=${existing !== undefined ? existing.port : '(new)'}`,

--- a/startos/actions/addServe.ts
+++ b/startos/actions/addServe.ts
@@ -49,8 +49,14 @@ export const addServe = sdk.Action.withInput(
 
     const existing = store[packageId]?.[interfaceId]
 
+    console.info(
+      `[addServe] ${packageId}/${interfaceId} existing:`,
+      JSON.stringify(existing ?? null),
+    )
+
     // Fully configured entry — nothing to do
     if (existing !== undefined && existing.hostId !== '') {
+      console.info(`[addServe] ${packageId}/${interfaceId} already configured — skipping`)
       return
     }
 

--- a/startos/plugin/url.ts
+++ b/startos/plugin/url.ts
@@ -25,9 +25,6 @@ export const exportUrls = sdk.plugin.url.setupExportedUrls(
     }> = []
 
     for (const [packageId, ifaces] of Object.entries(store)) {
-      // Skip StartOS self-target — not a supported serve target.
-      if (packageId === 'startos') continue
-
       for (const [interfaceId, entry] of Object.entries(ifaces)) {
         // Skip legacy entries — they have no hostId/scheme cached yet.
         // The URL plugin tile will continue to show "Add Serve"; the user
@@ -50,25 +47,30 @@ export const exportUrls = sdk.plugin.url.setupExportedUrls(
       candidates.map(async ({ packageId, interfaceId, port, hostId, scheme }) => {
         let internalPort: number
 
-        try {
-          const iface = await sdk.serviceInterface
-            .get(effects, { id: interfaceId, packageId })
-            .once()
+        if (packageId === 'startos') {
+          // StarOS has no registered service interface; UI is always at port 80
+          internalPort = 80
+        } else {
+          try {
+            const iface = await sdk.serviceInterface
+              .get(effects, { id: interfaceId, packageId })
+              .once()
 
-          if (!iface || !iface.addressInfo) {
+            if (!iface || !iface.addressInfo) {
+              console.warn(
+                `[plugin/url] interface ${packageId}/${interfaceId} not found (package uninstalled?), skipping`,
+              )
+              return
+            }
+
+            internalPort = iface.addressInfo.internalPort
+          } catch (e) {
             console.warn(
-              `[plugin/url] interface ${packageId}/${interfaceId} not found (package uninstalled?), skipping`,
+              `[plugin/url] could not resolve internalPort for ${packageId}/${interfaceId}, skipping:`,
+              e,
             )
             return
           }
-
-          internalPort = iface.addressInfo.internalPort
-        } catch (e) {
-          console.warn(
-            `[plugin/url] could not resolve internalPort for ${packageId}/${interfaceId}, skipping:`,
-            e,
-          )
-          return
         }
 
         // PluginHostnameInfo only exposes `ssl: boolean`, which StartOS maps

--- a/startos/plugin/url.ts
+++ b/startos/plugin/url.ts
@@ -81,7 +81,7 @@ export const exportUrls = sdk.plugin.url.setupExportedUrls(
         // expected; only the displayed protocol label is wrong. Track the
         // upstream SDK/platform change to add a TCP label before reworking
         // this.
-        const ssl = scheme === 'https' || scheme === 'wss'
+        const ssl = scheme === 'http' || scheme === 'ws' || scheme === 'https' || scheme === 'wss'
 
         await sdk.plugin.url
           .exportUrl(effects, {

--- a/startos/plugin/url.ts
+++ b/startos/plugin/url.ts
@@ -81,12 +81,14 @@ export const exportUrls = sdk.plugin.url.setupExportedUrls(
         // expected; only the displayed protocol label is wrong. Track the
         // upstream SDK/platform change to add a TCP label before reworking
         // this.
-        const ssl = scheme === 'http' || scheme === 'ws' || scheme === 'https' || scheme === 'wss'
+        const ssl = scheme === 'https' || scheme === 'wss'
 
         await sdk.plugin.url
           .exportUrl(effects, {
             hostnameInfo: {
-              packageId,
+              // StarOS self-target uses packageId=null in platform terms;
+              // other services use their string packageId.
+              packageId: packageId === 'startos' ? null : packageId,
               hostId,
               internalPort,
               ssl,

--- a/startos/serves.ts
+++ b/startos/serves.ts
@@ -46,14 +46,6 @@ export async function applyServicesConfig(
 
   let count = 0
   for (const [packageId, ifaces] of Object.entries(store)) {
-    // Skip StartOS self-target — not a supported serve target.
-    if (packageId === 'startos') {
-      console.info(
-        `[serves] skipping startos self-target (not supported)`,
-      )
-      continue
-    }
-
     for (const [interfaceId, entry] of Object.entries(ifaces)) {
       // Skip legacy entries — they have no cached metadata yet
       if (entry.hostId === '') {
@@ -64,7 +56,8 @@ export async function applyServicesConfig(
       }
 
       const { port, scheme, internalPort } = entry
-      const host = `${packageId}.startos`
+      // StarOS UI is reachable at 'startos'; other services use '<packageId>.startos'
+      const host = packageId === 'startos' ? 'startos' : `${packageId}.startos`
 
       let target: string
       let isHttpProxy: boolean


### PR DESCRIPTION
Closes #6

## Summary

- Remove the `packageId === 'startos'` bail-out in `addServe.ts`; use hardcoded `scheme='http'` and `internalPort=80` since StarOS has no registered service interface
- Remove the `startos` skip loop in `serves.ts`; resolve the upstream hostname as `'startos'` instead of `'startos.startos'` (matching the LXC bridge DNS pattern, same as `tor-startos`)
- Remove the `startos` skip in `plugin/url.ts`; bypass `serviceInterface.get()` for the platform self-target and use `internalPort=80` directly

## Investigation

The StarOS UI is reachable from inside the tailscale SubContainer at hostname `startos` on port 80. Confirmed by `curl -kvSL -I http://startos:80` returning HTTP 200. The `${packageId}.startos` pattern used for other services resolves to `<pkg>.startos`; for the platform itself, the hostname is just `startos` (no suffix) — consistent with how `tor-startos` handles it.

## Changes

| File | Change |
|------|--------|
| `startos/actions/addServe.ts` | Remove bail-out; branch on `packageId === 'startos'` for interface lookup |
| `startos/serves.ts` | Remove skip; use `'startos'` hostname for self-target |
| `startos/plugin/url.ts` | Remove skip; bypass interface lookup, use `internalPort=80` |

No new files, no schema changes, no store format changes. Build passes cleanly.