### PR TITLE
feat: allow user to specify port in Add Serve action

### DIFF
--- a/startos/actions/addServe.ts
+++ b/startos/actions/addServe.ts
@@ -3,7 +3,6 @@ import { shape, storeJson } from '../fileModels/store.json'
 import { applyServicesConfig } from '../serves'
 import { sdk } from '../sdk'
 import { assignPort, isPortAvailable, BLOCKED_PORTS } from '../utils'
-import { UI_PORT } from '../constants'
 
 const STATE_DIR = '/var/lib/tailscale'
 
@@ -21,6 +20,7 @@ const inputSpec = InputSpec.of({
     description:
       'Port to expose on your Tailscale network. Leave blank to auto-assign.',
     required: false,
+    default: null,
     integer: true,
     min: 1,
     max: 65535,
@@ -112,7 +112,7 @@ export const addServe = sdk.Action.withInput(
     } else if (input.port !== null && input.port !== undefined) {
       if (!isPortAvailable(store, input.port)) {
         const blocked = [...BLOCKED_PORTS].join(', ')
-        return sdk.Action.result.failure(
+        throw new Error(
           `Port ${input.port} is reserved or already in use. ` +
           `Blocked ports: ${blocked}. Choose a different port or leave blank to auto-assign.`,
         )

--- a/startos/actions/addServe.ts
+++ b/startos/actions/addServe.ts
@@ -2,7 +2,8 @@ import { z } from '@start9labs/start-sdk'
 import { shape, storeJson } from '../fileModels/store.json'
 import { applyServicesConfig } from '../serves'
 import { sdk } from '../sdk'
-import { assignPort } from '../utils'
+import { assignPort, isPortAvailable, BLOCKED_PORTS } from '../utils'
+import { UI_PORT } from '../constants'
 
 const STATE_DIR = '/var/lib/tailscale'
 
@@ -15,6 +16,16 @@ const inputSpec = InputSpec.of({
     hostId: string
     internalPort: number
   }>(),
+  port: Value.number({
+    name: 'Tailnet Port',
+    description:
+      'Port to expose on your Tailscale network. Leave blank to auto-assign.',
+    required: false,
+    integer: true,
+    min: 1,
+    max: 65535,
+    placeholder: 'auto-assign',
+  }),
 })
 
 export const addServe = sdk.Action.withInput(
@@ -42,7 +53,6 @@ export const addServe = sdk.Action.withInput(
     const { packageId: rawPkgId, interfaceId, hostId, internalPort } =
       input.urlPluginMetadata
     const packageId = rawPkgId ?? 'startos'
-
     // Use .once() to avoid "write after const" error
     const store: z.infer<typeof shape> =
       (await storeJson.read().once()) || {}
@@ -92,8 +102,25 @@ export const addServe = sdk.Action.withInput(
       `[addServe] ${packageId}/${interfaceId} resolved → scheme=${scheme}, internalPort=${resolvedInternalPort}, tailnetPort=${existing !== undefined ? existing.port : '(new)'}`,
     )
 
-    // Reuse existing port on legacy-upgrade; assign new port for fresh entry
-    const port = existing !== undefined ? existing.port : assignPort(store)
+    // Determine tailnet port:
+    //   1. Legacy-upgrade: reuse the existing stored port.
+    //   2. User supplied a port: validate it, then use it.
+    //   3. Blank: auto-assign the next sequential port.
+    let port: number
+    if (existing !== undefined) {
+      port = existing.port
+    } else if (input.port !== null && input.port !== undefined) {
+      if (!isPortAvailable(store, input.port)) {
+        const blocked = [...BLOCKED_PORTS].join(', ')
+        return sdk.Action.result.failure(
+          `Port ${input.port} is reserved or already in use. ` +
+          `Blocked ports: ${blocked}. Choose a different port or leave blank to auto-assign.`,
+        )
+      }
+      port = input.port
+    } else {
+      port = assignPort(store)
+    }
 
     const entry = {
       port,

--- a/startos/constants.ts
+++ b/startos/constants.ts
@@ -1,0 +1,2 @@
+/** Port the Tailscale web UI listens on. */
+export const UI_PORT = 8080

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -3,8 +3,7 @@ import { statusJson } from './fileModels/status.json'
 import { storeJson } from './fileModels/store.json'
 import { parseTailscaleIp, parseDnsName } from './utils'
 import { applyServicesConfig } from './serves'
-
-const UI_PORT = 8080
+import { UI_PORT } from './constants'
 const STATE_DIR = '/var/lib/tailscale'
 const SOCKET = '/var/run/tailscale/tailscaled.sock'
 

--- a/startos/utils.ts
+++ b/startos/utils.ts
@@ -1,5 +1,14 @@
 import { z } from '@start9labs/start-sdk'
 import { shape } from './fileModels/store.json'
+import { UI_PORT } from './constants'
+
+/**
+ * Ports that Tailscale reserves on the tailnet or uses internally.
+ * These cannot be used for serve entries.
+ *  - 80, 443: reserved by Tailscale for HTTP/HTTPS on the tailnet
+ *  - UI_PORT (8080): the Tailscale web UI
+ */
+export const BLOCKED_PORTS = new Set([80, 443, UI_PORT])
 
 /**
  * Assigns the next available Tailscale serve port.
@@ -10,6 +19,22 @@ export function assignPort(store: z.infer<typeof shape>): number {
     Object.values(ifaces).map((e) => e.port),
   )
   return Math.max(9999, ...allPorts) + 1
+}
+
+/**
+ * Returns true if the given port is free to use for a new serve entry.
+ * Rejects ports blocked by Tailscale (80, 443) or the web UI (8080),
+ * and any port already assigned to an existing serve entry.
+ */
+export function isPortAvailable(
+  store: z.infer<typeof shape>,
+  port: number,
+): boolean {
+  if (BLOCKED_PORTS.has(port)) return false
+  const allPorts = Object.values(store).flatMap((ifaces) =>
+    Object.values(ifaces).map((e) => e.port),
+  )
+  return !allPorts.includes(port)
 }
 
 /**


### PR DESCRIPTION
Closes #9

## Summary

- Add optional **Tailnet Port** field to the Add Serve action — blank = auto-assign (existing behaviour unchanged)
- Reject user-supplied ports that are blocked (`80`, `443`, `8080`) or already assigned to another serve entry
- Extract `UI_PORT` to a shared `constants.ts` to avoid a circular import between `main.ts` and `addServe.ts`

## Implementation Plan

### New file: `startos/constants.ts`
Exports `UI_PORT = 8080` so it can be shared without circular imports.

### `startos/main.ts`
Import `UI_PORT` from `./constants` instead of defining it locally.

### `startos/utils.ts`
- `BLOCKED_PORTS` — `Set([80, 443, UI_PORT])`: ports Tailscale reserves on the tailnet plus the web UI port
- `isPortAvailable(store, port)` — returns `false` if port is blocked or already in use by an existing serve entry

### `startos/actions/addServe.ts`
- Add optional `port` number field (`1–65535`) to `inputSpec`; placeholder text reads "auto-assign"
- Port resolution order in execution:
  1. Existing entry (legacy-upgrade) → reuse stored port
  2. User supplied a port → validate with `isPortAvailable`, return descriptive failure if rejected
  3. Blank → `assignPort()` auto-assign as before

## Files changed

| File | Change |
|---|---|
| `startos/constants.ts` | **New** — exports `UI_PORT = 8080` |
| `startos/main.ts` | Import `UI_PORT` from `./constants` |
| `startos/utils.ts` | Add `BLOCKED_PORTS` and `isPortAvailable()` |
| `startos/actions/addServe.ts` | Add optional port field + validation logic |