### PR TITLE
feat: add Set Machine Name action and require setup before first launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ traffic is handled internally by tailscaled in userspace networking mode.
 Visible in the Actions panel. Works whether the service is running or stopped.
 
 Sets the hostname this node advertises on your Tailscale network (and its MagicDNS name
-if MagicDNS is enabled). The default is `startos`.
+if MagicDNS is enabled). The default is `startos`. All serve URLs
+(e.g. `mynode.tail1234.ts.net:10001`) update automatically once Tailscale confirms
+the new name.
 
 > **Note:** This action only has an effect when **"Auto-generate from OS hostname"** is
 > enabled in the [Tailscale admin console](https://login.tailscale.com/admin/machines)
@@ -153,10 +155,12 @@ if MagicDNS is enabled). The default is `startos`.
 - **On install:** a critical task is automatically created, blocking startup until
   the user runs this action and confirms or changes the name.
 - **While stopped:** stores the name; the `set-hostname` startup oneshot applies
-  it via `tailscale set --hostname` when the service next starts.
+  it via `tailscale set --hostname` when the service next starts. Serve URLs
+  update after the service starts and Tailscale confirms the new name.
 - **While running:** stores the name and attempts immediate application via a
   shared temp subcontainer. If the daemon is reachable the rename takes effect
-  instantly without a restart.
+  instantly without a restart; serve URLs update within one health-check cycle
+  (~10 s) once Tailscale reflects the new `Self.DNSName`.
 - Re-running this action (rename) resets `hostnameSet` so the startup oneshot
   will reconfirm the name on the next start.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ temp containers can reach the tailscaled Unix socket):
 **Key files:**
 
 - `tailscale/tailscaled.state` — node identity, keys, and tailnet membership
-- `startos/store.json` — maps `{ packageId: { interfaceId: { port, hostId, scheme, internalPort } } }` for all configured serves
+- `startos/store.json` — top-level object containing `machineName` (the Tailscale hostname), `hostnameSet` (bool, true once applied), and `serves` (maps `{ packageId: { interfaceId: { port, hostId, scheme, internalPort } } }` for all configured serves)
 - `startos/status.json` — cached `{ ip, dnsName }` written on each successful health check
 
 All state persists across restarts. The node retains its Tailscale IP address as
@@ -75,14 +75,18 @@ long as `tailscaled.state` is intact.
 ## Installation and First-Run Flow
 
 1. Install Tailscale from the StartOS marketplace.
-2. Start the service. The two daemons start in sequence.
-3. Open the **Web Interface** from the StartOS UI.
-4. Log in with your Tailscale account to join the node to your tailnet.
-5. Optionally configure subnet routes, exit node, or Tailscale SSH from the web interface.
-6. Use the **Add Serve** tile action on any installed service to expose it on your tailnet.
+2. A critical task will appear prompting you to **Set Machine Name**. This is the
+   hostname your node will advertise on your Tailscale network. The default is
+   `startos`. Accept the default or enter a custom name, then complete the task.
+3. Start the service. The daemons start in sequence and the chosen machine name
+   is applied automatically via `tailscale set --hostname`.
+4. Open the **Web Interface** from the StartOS UI.
+5. Log in with your Tailscale account to join the node to your tailnet.
+6. Optionally configure subnet routes, exit node, or Tailscale SSH from the web interface.
+7. Use the **Add Serve** tile action on any installed service to expose it on your tailnet.
 
-No auth key or pre-configuration is required. All setup happens interactively
-through the Tailscale web interface.
+No auth key or pre-configuration is required beyond the machine name step.
+All other setup happens interactively through the Tailscale web interface.
 
 ---
 
@@ -94,6 +98,7 @@ All Tailscale configuration is managed through the **Tailscale web interface**
 | Feature             | How to configure                          |
 | ------------------- | ----------------------------------------- |
 | Login / auth        | Web UI → Sign in                          |
+| Machine name        | Actions panel → Set Machine Name          |
 | Subnet router       | Web UI → Settings → Subnet router         |
 | Exit node           | Web UI → This device → Exit node          |
 | Tailscale SSH       | Web UI → Settings → Tailscale SSH server  |
@@ -131,6 +136,23 @@ traffic is handled internally by tailscaled in userspace networking mode.
 ---
 
 ## Actions (StartOS UI)
+
+### Set Machine Name
+
+Visible in the Actions panel. Works whether the service is running or stopped.
+
+Sets the hostname this node advertises on your Tailscale network (and its MagicDNS name
+if MagicDNS is enabled). The default is `startos`.
+
+- **On install:** a critical task is automatically created, blocking startup until
+  the user runs this action and confirms or changes the name.
+- **While stopped:** stores the name; the `set-hostname` startup oneshot applies
+  it via `tailscale set --hostname` when the service next starts.
+- **While running:** stores the name and attempts immediate application via a
+  shared temp subcontainer. If the daemon is reachable the rename takes effect
+  instantly without a restart.
+- Re-running this action (rename) resets `hostnameSet` so the startup oneshot
+  will reconfirm the name on the next start.
 
 ### Add Serve / Remove Serve
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Visible in the Actions panel. Works whether the service is running or stopped.
 Sets the hostname this node advertises on your Tailscale network (and its MagicDNS name
 if MagicDNS is enabled). The default is `startos`.
 
+> **Note:** This action only has an effect when **"Auto-generate from OS hostname"** is
+> enabled in the [Tailscale admin console](https://login.tailscale.com/admin/machines)
+> — this is the default for new machines. If you have manually renamed this machine in
+> the admin console, the admin-console name takes precedence and this action will have
+> no visible effect until you re-enable auto-generation there.
+
 - **On install:** a critical task is automatically created, blocking startup until
   the user runs this action and confirms or changes the name.
 - **While stopped:** stores the name; the `set-hostname` startup oneshot applies

--- a/startos/actions/addServe.ts
+++ b/startos/actions/addServe.ts
@@ -1,8 +1,8 @@
-import { z } from '@start9labs/start-sdk'
-import { shape, storeJson } from '../fileModels/store.json'
+import { servesShape, storeJson } from '../fileModels/store.json'
 import { applyServicesConfig } from '../serves'
 import { sdk } from '../sdk'
 import { assignPort, isPortAvailable, BLOCKED_PORTS } from '../utils'
+import { z } from '@start9labs/start-sdk'
 
 const STATE_DIR = '/var/lib/tailscale'
 
@@ -54,10 +54,14 @@ export const addServe = sdk.Action.withInput(
       input.urlPluginMetadata
     const packageId = rawPkgId ?? 'startos'
     // Use .once() to avoid "write after const" error
-    const store: z.infer<typeof shape> =
-      (await storeJson.read().once()) || {}
+    const storeData = (await storeJson.read().once()) ?? {
+      machineName: 'startos',
+      hostnameSet: false,
+      serves: {},
+    }
+    const serves: z.infer<typeof servesShape> = storeData.serves
 
-    const existing = store[packageId]?.[interfaceId]
+    const existing = serves[packageId]?.[interfaceId]
 
     console.info(
       `[addServe] ${packageId}/${interfaceId} existing:`,
@@ -110,7 +114,7 @@ export const addServe = sdk.Action.withInput(
     if (existing !== undefined) {
       port = existing.port
     } else if (input.port !== null && input.port !== undefined) {
-      if (!isPortAvailable(store, input.port)) {
+      if (!isPortAvailable(serves, input.port)) {
         const blocked = [...BLOCKED_PORTS].join(', ')
         throw new Error(
           `Port ${input.port} is reserved or already in use. ` +
@@ -119,7 +123,7 @@ export const addServe = sdk.Action.withInput(
       }
       port = input.port
     } else {
-      port = assignPort(store)
+      port = assignPort(serves)
     }
 
     const entry = {
@@ -129,9 +133,9 @@ export const addServe = sdk.Action.withInput(
       internalPort: resolvedInternalPort,
     }
 
-    const updated: z.infer<typeof shape> = {
-      ...store,
-      [packageId]: { ...(store[packageId] ?? {}), [interfaceId]: entry },
+    const updatedServes: z.infer<typeof servesShape> = {
+      ...serves,
+      [packageId]: { ...(serves[packageId] ?? {}), [interfaceId]: entry },
     }
 
     const mounts = sdk.Mounts.of().mountVolume({
@@ -147,10 +151,10 @@ export const addServe = sdk.Action.withInput(
       mounts,
       'tailscale-serve-add',
       async (sub) => {
-        await applyServicesConfig(sub, updated)
+        await applyServicesConfig(sub, updatedServes)
       },
     )
 
-    await storeJson.write(effects, updated)
+    await storeJson.write(effects, { ...storeData, serves: updatedServes })
   },
 )

--- a/startos/actions/index.ts
+++ b/startos/actions/index.ts
@@ -1,7 +1,9 @@
 import { sdk } from '../sdk'
 import { addServe } from './addServe'
 import { removeServe } from './removeServe'
+import { setMachineName } from './setMachineName'
 
 export const actions = sdk.Actions.of()
+  .addAction(setMachineName)
   .addAction(addServe)
   .addAction(removeServe)

--- a/startos/actions/removeServe.ts
+++ b/startos/actions/removeServe.ts
@@ -1,7 +1,7 @@
-import { z } from '@start9labs/start-sdk'
-import { shape, storeJson } from '../fileModels/store.json'
+import { servesShape, storeJson } from '../fileModels/store.json'
 import { applyServicesConfig } from '../serves'
 import { sdk } from '../sdk'
+import { z } from '@start9labs/start-sdk'
 
 const STATE_DIR = '/var/lib/tailscale'
 
@@ -47,23 +47,27 @@ export const removeServe = sdk.Action.withInput(
     const packageId = rawPkgId ?? 'startos'
 
     // Use .once() to avoid "write after const" error
-    const store: z.infer<typeof shape> =
-      (await storeJson.read().once()) || {}
+    const storeData = (await storeJson.read().once()) ?? {
+      machineName: 'startos',
+      hostnameSet: false,
+      serves: {},
+    }
+    const serves: z.infer<typeof servesShape> = storeData.serves
 
-    if (store[packageId]?.[interfaceId] === undefined) {
+    if (serves[packageId]?.[interfaceId] === undefined) {
       return
     }
 
     // Remove the entry, preserving all other packages/interfaces
-    const updated: z.infer<typeof shape> = {}
-    for (const [pkg, ifaces] of Object.entries(store)) {
-      const filteredIfaces: z.infer<typeof shape>[string] = {}
+    const updatedServes: z.infer<typeof servesShape> = {}
+    for (const [pkg, ifaces] of Object.entries(serves)) {
+      const filteredIfaces: z.infer<typeof servesShape>[string] = {}
       for (const [iface, entry] of Object.entries(ifaces)) {
         if (pkg === packageId && iface === interfaceId) continue
         filteredIfaces[iface] = entry
       }
       if (Object.keys(filteredIfaces).length > 0) {
-        updated[pkg] = filteredIfaces
+        updatedServes[pkg] = filteredIfaces
       }
     }
 
@@ -80,10 +84,10 @@ export const removeServe = sdk.Action.withInput(
       mounts,
       'tailscale-serve-remove',
       async (sub) => {
-        await applyServicesConfig(sub, updated)
+        await applyServicesConfig(sub, updatedServes)
       },
     )
 
-    await storeJson.write(effects, updated)
+    await storeJson.write(effects, { ...storeData, serves: updatedServes })
   },
 )

--- a/startos/actions/setMachineName.ts
+++ b/startos/actions/setMachineName.ts
@@ -41,6 +41,8 @@ export const setMachineName = sdk.Action.withInput(
     name: 'Set Machine Name',
     description:
       'Set the hostname this node advertises on your Tailscale network. ' +
+      'Serve URLs (e.g. mynode.tail1234.ts.net:10001) update automatically ' +
+      'once Tailscale confirms the new name. ' +
       'This only takes effect if "Auto-generate from OS hostname" is enabled ' +
       '(the default) in the Tailscale admin console. If you have manually ' +
       'renamed this machine in the admin console, that name takes precedence. ' +

--- a/startos/actions/setMachineName.ts
+++ b/startos/actions/setMachineName.ts
@@ -10,7 +10,9 @@ const inputSpec = InputSpec.of({
   machineName: Value.text({
     name: 'Machine Name',
     description:
-      'The name this node will advertise on your Tailscale network. ' +
+      'The hostname this node will advertise on your Tailscale network. ' +
+      'Only takes effect when "Auto-generate from OS hostname" is enabled ' +
+      '(the default) in the Tailscale admin console. ' +
       'Must be 1–63 characters: lowercase letters, numbers, and hyphens only. ' +
       'Cannot start or end with a hyphen. ' +
       'If MagicDNS is enabled, this also determines the MagicDNS hostname.',
@@ -38,9 +40,17 @@ export const setMachineName = sdk.Action.withInput(
   async () => ({
     name: 'Set Machine Name',
     description:
-      'Set the Tailscale machine name for this node. ' +
-      'This must be completed before the service can start for the first time.',
-    warning: null,
+      'Set the hostname this node advertises on your Tailscale network. ' +
+      'This only takes effect if "Auto-generate from OS hostname" is enabled ' +
+      '(the default) in the Tailscale admin console. If you have manually ' +
+      'renamed this machine in the admin console, that name takes precedence. ' +
+      'Must be completed before the service can start for the first time.',
+    warning:
+      'This action only controls the hostname sent to Tailscale via ' +
+      '`tailscale set --hostname`. If you have manually renamed this machine ' +
+      'in the Tailscale admin console, the admin-console name takes precedence ' +
+      'and this setting has no visible effect until you re-enable ' +
+      '"Auto-generate from OS hostname" in the admin console.',
     allowedStatuses: 'any',
     group: null,
     visibility: 'enabled',

--- a/startos/actions/setMachineName.ts
+++ b/startos/actions/setMachineName.ts
@@ -11,12 +11,19 @@ const inputSpec = InputSpec.of({
     name: 'Machine Name',
     description:
       'The name this node will advertise on your Tailscale network. ' +
-      'Must be lowercase letters, numbers, and hyphens only. ' +
+      'Must be 1–63 characters: lowercase letters, numbers, and hyphens only. ' +
+      'Cannot start or end with a hyphen. ' +
       'If MagicDNS is enabled, this also determines the MagicDNS hostname.',
     required: true,
     default: 'startos',
     placeholder: 'startos',
-    patterns: [],
+    patterns: [
+      {
+        regex: '^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$',
+        description:
+          'Lowercase letters, numbers, and hyphens only; cannot start or end with a hyphen.',
+      },
+    ],
     masked: false,
     minLength: 1,
     maxLength: 63,
@@ -50,7 +57,7 @@ export const setMachineName = sdk.Action.withInput(
 
   // execution
   async ({ effects, input }) => {
-    const machineName = input.machineName.trim()
+    const machineName = input.machineName.trim().toLowerCase()
 
     if (!machineName) {
       throw new Error('Machine name cannot be empty.')
@@ -98,9 +105,16 @@ export const setMachineName = sdk.Action.withInput(
           ])
 
           if (r.exitCode === 0) {
+            // Re-read the latest store to avoid overwriting concurrent writes
+            // (e.g. addServe/removeServe running between our two writes).
+            const latestStoreData = (await storeJson.read().once()) ?? {
+              machineName: 'startos',
+              hostnameSet: false,
+              serves: {},
+            }
             // Mark applied so the startup oneshot skips the redundant set.
             await storeJson.write(effects, {
-              ...storeData,
+              ...latestStoreData,
               machineName,
               hostnameSet: true,
             })

--- a/startos/actions/setMachineName.ts
+++ b/startos/actions/setMachineName.ts
@@ -1,0 +1,125 @@
+import { sdk } from '../sdk'
+import { storeJson } from '../fileModels/store.json'
+
+const STATE_DIR = '/var/lib/tailscale'
+const SOCKET = '/var/run/tailscale/tailscaled.sock'
+
+const { InputSpec, Value } = sdk
+
+const inputSpec = InputSpec.of({
+  machineName: Value.text({
+    name: 'Machine Name',
+    description:
+      'The name this node will advertise on your Tailscale network. ' +
+      'Must be lowercase letters, numbers, and hyphens only. ' +
+      'If MagicDNS is enabled, this also determines the MagicDNS hostname.',
+    required: true,
+    default: 'startos',
+    placeholder: 'startos',
+    patterns: [],
+    masked: false,
+    minLength: 1,
+    maxLength: 63,
+  }),
+})
+
+export const setMachineName = sdk.Action.withInput(
+  // id
+  'set-machine-name',
+
+  // metadata
+  async () => ({
+    name: 'Set Machine Name',
+    description:
+      'Set the Tailscale machine name for this node. ' +
+      'This must be completed before the service can start for the first time.',
+    warning: null,
+    allowedStatuses: 'any',
+    group: null,
+    visibility: 'enabled',
+  }),
+
+  // input spec
+  inputSpec,
+
+  // pre-fill: read the currently stored machine name
+  async ({ effects }) => {
+    const store = await storeJson.read().once()
+    return { machineName: store?.machineName ?? 'startos' }
+  },
+
+  // execution
+  async ({ effects, input }) => {
+    const machineName = input.machineName.trim()
+
+    if (!machineName) {
+      throw new Error('Machine name cannot be empty.')
+    }
+
+    // Persist the chosen name and reset hostnameSet so the startup oneshot
+    // re-applies the name on the next start (handles both first-install and
+    // subsequent rename-while-stopped flows).
+    const storeData = (await storeJson.read().once()) ?? {
+      machineName: 'startos',
+      hostnameSet: false,
+      serves: {},
+    }
+
+    await storeJson.write(effects, {
+      ...storeData,
+      machineName,
+      hostnameSet: false,
+    })
+
+    // If the service is currently running, apply the rename immediately via a
+    // shared temp subcontainer so the change takes effect without a restart.
+    // If the daemon isn't running yet (e.g. first-install, service stopped),
+    // the write above is enough — the set-hostname oneshot picks it up on
+    // the next start.
+    try {
+      const mounts = sdk.Mounts.of().mountVolume({
+        volumeId: 'tailscale',
+        subpath: null,
+        mountpoint: STATE_DIR,
+        readonly: false,
+      })
+
+      await sdk.SubContainer.withTemp(
+        effects,
+        { imageId: 'tailscale', sharedRun: true },
+        mounts,
+        'tailscale-set-hostname',
+        async (sub) => {
+          const r = await sub.exec([
+            'tailscale',
+            '--socket=' + SOCKET,
+            'set',
+            '--hostname=' + machineName,
+          ])
+
+          if (r.exitCode === 0) {
+            // Mark applied so the startup oneshot skips the redundant set.
+            await storeJson.write(effects, {
+              ...storeData,
+              machineName,
+              hostnameSet: true,
+            })
+            console.info(`[set-machine-name] applied immediately: ${machineName}`)
+          } else {
+            // Daemon not running — startup oneshot will apply on next start.
+            console.info(
+              `[set-machine-name] daemon not running (exit ${r.exitCode}), ` +
+              `name saved to store; will apply on next start`,
+            )
+          }
+        },
+      )
+    } catch (e) {
+      // Any error here means the daemon isn't running; startup oneshot handles it.
+      console.info(
+        '[set-machine-name] could not reach running daemon, name will be applied on next start:',
+        e,
+      )
+    }
+  },
+)

--- a/startos/fileModels/store.json.ts
+++ b/startos/fileModels/store.json.ts
@@ -94,7 +94,7 @@ const currentShape = z.object({
 })
 
 export const shape = z
-  .union([currentShape, servesShape])
+  .union([servesShape, currentShape])
   .transform((value) =>
     'serves' in value
       ? (value as z.infer<typeof currentShape>)

--- a/startos/fileModels/store.json.ts
+++ b/startos/fileModels/store.json.ts
@@ -82,14 +82,30 @@ export const servesShape = z.record(
  *
  * `serves` — the per-package/interface serve port-mapping table (the entire
  *   former top-level shape, now nested).
+ *
+ * A z.union is used to accept the legacy top-level serves format (from
+ * before the store was refactored) and migrate it transparently so that
+ * existing installs don't break on upgrade.
  */
-export const shape = z.object({
+const currentShape = z.object({
   machineName: z.string().default('startos'),
   hostnameSet: z.boolean().default(false),
   serves: servesShape.default({}),
 })
 
-export type Store = z.infer<typeof shape>
+export const shape = z
+  .union([currentShape, servesShape])
+  .transform((value) =>
+    'serves' in value
+      ? (value as z.infer<typeof currentShape>)
+      : {
+          machineName: 'startos',
+          hostnameSet: false,
+          serves: value as z.infer<typeof servesShape>,
+        },
+  )
+
+export type Store = z.infer<typeof currentShape>
 
 export const storeJson = FileHelper.json(
   {

--- a/startos/fileModels/store.json.ts
+++ b/startos/fileModels/store.json.ts
@@ -42,8 +42,8 @@ const legacySentinel = (port: number): StoreEntry => ({
   internalPort: 0,
 })
 
-// shape: { [packageId]: { [interfaceId]: StoreEntry } }
-export const shape = z.record(
+/** Shape of the serves sub-map: { [packageId]: { [interfaceId]: StoreEntry } } */
+export const servesShape = z.record(
   z.string(),
   z.record(
     z.string(),
@@ -68,6 +68,28 @@ export const shape = z.record(
     ]),
   ),
 )
+
+/**
+ * Top-level store shape.
+ *
+ * `machineName` — the Tailscale machine/hostname to advertise.  Defaults to
+ *   'startos' and is set by the user via the Set Machine Name action before
+ *   the service starts for the first time.
+ *
+ * `hostnameSet` — true once the startup oneshot has successfully applied
+ *   the machine name via `tailscale set --hostname`.  Prevents redundant
+ *   re-application on every restart after the initial set.
+ *
+ * `serves` — the per-package/interface serve port-mapping table (the entire
+ *   former top-level shape, now nested).
+ */
+export const shape = z.object({
+  machineName: z.string().default('startos'),
+  hostnameSet: z.boolean().default(false),
+  serves: servesShape.default({}),
+})
+
+export type Store = z.infer<typeof shape>
 
 export const storeJson = FileHelper.json(
   {

--- a/startos/init/index.ts
+++ b/startos/init/index.ts
@@ -5,6 +5,7 @@ import { versionGraph } from '../versions'
 import { restoreInit } from '../backups'
 import { actions } from '../actions'
 import { registerUrlPlugin, exportUrls } from '../plugin/url'
+import { initializeService } from './initializeService'
 
 export const init = sdk.setupInit(
   restoreInit,
@@ -14,6 +15,7 @@ export const init = sdk.setupInit(
   actions,
   registerUrlPlugin,
   exportUrls,
+  initializeService,
 )
 
 export const uninit = sdk.setupUninit(versionGraph)

--- a/startos/init/initializeService.ts
+++ b/startos/init/initializeService.ts
@@ -1,0 +1,24 @@
+import { sdk } from '../sdk'
+import { storeJson } from '../fileModels/store.json'
+import { setMachineName } from '../actions/setMachineName'
+
+export const initializeService = sdk.setupOnInit(async (effects, kind) => {
+  if (kind !== 'install') return
+
+  // Write initial store defaults so the machine name action pre-fills correctly
+  // and the startup oneshot has a well-typed value to read.
+  await storeJson.write(effects, {
+    machineName: 'startos',
+    hostnameSet: false,
+    serves: {},
+  })
+
+  // Create a critical task that blocks the service from starting until the
+  // user confirms (or changes) the machine name.  The default is 'startos';
+  // the user can accept it immediately or pick a custom name.
+  await sdk.action.createOwnTask(effects, setMachineName, 'critical', {
+    reason:
+      'Set your Tailscale machine name before starting the service. ' +
+      "The default is 'startos'. Accept the default or enter a custom name.",
+  })
+})

--- a/startos/init/initializeService.ts
+++ b/startos/init/initializeService.ts
@@ -19,6 +19,8 @@ export const initializeService = sdk.setupOnInit(async (effects, kind) => {
   await sdk.action.createOwnTask(effects, setMachineName, 'critical', {
     reason:
       'Set your Tailscale machine name before starting the service. ' +
-      "The default is 'startos'. Accept the default or enter a custom name.",
+      "The default is 'startos'. Accept the default or enter a custom name. " +
+      'This only takes effect when "Auto-generate from OS hostname" is enabled ' +
+      '(the default) in the Tailscale admin console.',
   })
 })

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -146,14 +146,62 @@ export const main = sdk.setupMain(async ({ effects }) => {
             )
           }
 
-          const store = (await storeJson.read().once()) || {}
-          if (Object.keys(store).length > 0) {
-            await applyServicesConfig(subcontainer, store)
+          const storeData = (await storeJson.read().once()) ?? {
+            machineName: 'startos',
+            hostnameSet: false,
+            serves: {},
+          }
+          const serves = storeData.serves
+          if (Object.keys(serves).length > 0) {
+            await applyServicesConfig(subcontainer, serves)
           }
           return null
         },
       },
       requires: ['tailscaled'],
+    })
+    .addOneshot('set-hostname', {
+      subcontainer,
+      exec: {
+        fn: async () => {
+          // Apply the user-chosen machine name via `tailscale set --hostname`.
+          // We do this once per first-connect (hostnameSet === false) and skip
+          // on subsequent restarts to avoid overwriting admin-console renames.
+          // If the user re-runs the Set Machine Name action while stopped, it
+          // resets hostnameSet to false, causing this oneshot to re-apply.
+          const storeData = (await storeJson.read().once()) ?? {
+            machineName: 'startos',
+            hostnameSet: false,
+            serves: {},
+          }
+
+          if (storeData.hostnameSet) {
+            console.info('[set-hostname] hostname already set, skipping')
+            return null
+          }
+
+          const name = storeData.machineName ?? 'startos'
+          console.info(`[set-hostname] applying hostname: ${name}`)
+
+          const r = await subcontainer.exec([
+            'tailscale',
+            '--socket=' + SOCKET,
+            'set',
+            '--hostname=' + name,
+          ])
+
+          if (r.exitCode !== 0) {
+            throw new Error(
+              `[set-hostname] tailscale set --hostname failed: ${r.stderr.toString()}`,
+            )
+          }
+
+          await storeJson.write(effects, { ...storeData, hostnameSet: true })
+          console.info(`[set-hostname] hostname set to: ${name}`)
+          return null
+        },
+      },
+      requires: ['restore-serves'],
     })
     .addDaemon('tailscale-web', {
       subcontainer,
@@ -173,6 +221,6 @@ export const main = sdk.setupMain(async ({ effects }) => {
             errorMessage: 'The web interface is not yet ready',
           }),
       },
-      requires: ['tailscaled', 'restore-serves'],
+      requires: ['tailscaled', 'set-hostname'],
     })
 })

--- a/startos/plugin/url.ts
+++ b/startos/plugin/url.ts
@@ -11,7 +11,11 @@ export const registerUrlPlugin = sdk.setupOnInit(async (effects) =>
 export const exportUrls = sdk.plugin.url.setupExportedUrls(
   async ({ effects }) => {
     // Reactive reads — framework re-runs this handler when either file changes.
-    const store = (await storeJson.read().const(effects)) || {}
+    const storeData = (await storeJson.read().const(effects)) ?? {
+      machineName: 'startos',
+      hostnameSet: false,
+      serves: {},
+    }
     const status = await statusJson.read().const(effects)
     if (!status) return
 
@@ -24,7 +28,7 @@ export const exportUrls = sdk.plugin.url.setupExportedUrls(
       scheme: string | null
     }> = []
 
-    for (const [packageId, ifaces] of Object.entries(store)) {
+    for (const [packageId, ifaces] of Object.entries(storeData.serves)) {
       for (const [interfaceId, entry] of Object.entries(ifaces)) {
         // Skip legacy entries — they have no hostId/scheme cached yet.
         // The URL plugin tile will continue to show "Add Serve"; the user

--- a/startos/serves.ts
+++ b/startos/serves.ts
@@ -1,5 +1,5 @@
 import { z } from '@start9labs/start-sdk'
-import { shape } from './fileModels/store.json'
+import { servesShape } from './fileModels/store.json'
 
 const SOCKET = '/var/run/tailscale/tailscaled.sock'
 
@@ -29,7 +29,7 @@ export async function applyServicesConfig(
       cmd: string[],
     ) => Promise<{ exitCode: number | null; stderr: Buffer | string }>
   },
-  store: z.infer<typeof shape>,
+  store: z.infer<typeof servesShape>,
 ): Promise<void> {
   // Reset all existing serves first
   const resetResult = await sub.exec([

--- a/startos/utils.ts
+++ b/startos/utils.ts
@@ -1,5 +1,5 @@
 import { z } from '@start9labs/start-sdk'
-import { shape } from './fileModels/store.json'
+import { servesShape } from './fileModels/store.json'
 import { UI_PORT } from './constants'
 
 /**
@@ -14,7 +14,7 @@ export const BLOCKED_PORTS = new Set([80, 443, UI_PORT])
  * Assigns the next available Tailscale serve port.
  * Starts at 10000, increments by 1 above the current max.
  */
-export function assignPort(store: z.infer<typeof shape>): number {
+export function assignPort(store: z.infer<typeof servesShape>): number {
   const allPorts = Object.values(store).flatMap((ifaces) =>
     Object.values(ifaces).map((e) => e.port),
   )
@@ -27,7 +27,7 @@ export function assignPort(store: z.infer<typeof shape>): number {
  * and any port already assigned to an existing serve entry.
  */
 export function isPortAvailable(
-  store: z.infer<typeof shape>,
+  store: z.infer<typeof servesShape>,
   port: number,
 ): boolean {
   if (BLOCKED_PORTS.has(port)) return false


### PR DESCRIPTION
## Summary

Closes #11

- **Set Machine Name action** (`allowedStatuses: 'any'`, visible in Actions panel): prompts the user for a Tailscale machine hostname, pre-filled with `startos`. Works stopped or running — applies immediately via shared temp subcontainer when the daemon is reachable, or defers to the startup oneshot when stopped.
- **Critical install task**: `initializeService` writes store defaults on `kind === 'install'` and raises a `critical` task pointing to the Set Machine Name action, blocking the service from starting until the user completes it.
- **`set-hostname` startup oneshot**: runs after `restore-serves`, reads `store.machineName`, calls `tailscale set --hostname=<name>`, and sets `hostnameSet: true`. Skips on subsequent restarts once already applied; resets when the user re-runs the action (rename).
- **Store schema refactor**: wraps the existing serves record in a top-level object with `machineName` (default `startos`) and `hostnameSet` (default `false`). Zod defaults ensure existing installs migrate gracefully without an explicit migration. All call sites updated: `addServe`, `removeServe`, `main.ts`, `serves.ts`, `utils.ts`, `plugin/url.ts`.

## Startup order after this change

```
tailscaled → restore-serves → set-hostname → tailscale-web
```