### PR TITLE
fix: bump fast-xml-parser to >=5.7.0 to resolve CVE-2026-41650

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
-      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
       "funding": [
         {
           "type": "github",
@@ -131,9 +131,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -142,8 +142,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^1.1.0",
-        "fast-xml-builder": "^1.1.4",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "prettier": "^3.6.2",
     "typescript": "^5.9.3"
   },
+  "overrides": {
+    "fast-xml-parser": ">=5.7.0"
+  },
   "prettier": {
     "trailingComma": "all",
     "tabWidth": 2,


### PR DESCRIPTION
## Summary

- Resolves Dependabot alert [#1](https://github.com/sudocarlos/tailscale-startos/security/dependabot/1): **CVE-2026-41650 / GHSA-gh4j-gqv2-49f6** (medium, CVSS 6.1)
- `fast-xml-parser` < 5.7.0 allows XML comment and CDATA injection via unescaped `-->` and `]]>` delimiters in `XMLBuilder`, enabling XSS, SOAP injection, and feed poisoning when user-controlled data flows into comments or CDATA sections
- `fast-xml-parser` is a transitive dependency via `@start9labs/start-sdk`; added an npm `overrides` entry to force the patched version (resolves to 5.7.1)