### PR TITLE
fix: always re-apply machine name on restart and allow addServe re-apply

### DIFF
--- a/startos/actions/addServe.ts
+++ b/startos/actions/addServe.ts
@@ -69,11 +69,11 @@ export const addServe = sdk.Action.withInput(
       JSON.stringify(existing ?? null),
     )
 
-    // Fully configured entry — nothing to do
-    if (existing !== undefined && existing.hostId !== '') {
-      console.info(`[addServe] ${packageId}/${interfaceId} already configured — skipping`)
-      return
-    }
+    // No early-return for already-configured entries — re-running add-serve
+    // always re-applies the serve so that entries lost (e.g. after
+    // uninstall/reinstall or manual `tailscale serve reset`) are restored.
+    // The port is preserved from the existing entry unless the user supplies
+    // a new one.
 
     // Resolve scheme and internal port from the service interface.
     // StarOS itself has no registered service interface; its UI is always
@@ -108,14 +108,19 @@ export const addServe = sdk.Action.withInput(
     )
 
     // Determine tailnet port:
-    //   1. Legacy-upgrade: reuse the existing stored port.
-    //   2. User supplied a port: validate it, then use it.
-    //   3. Blank: auto-assign the next sequential port.
+    //   1. User supplied a port: validate it, then use it (even for existing entries).
+    //   2. Existing fully-configured entry and no port supplied: preserve stored port.
+    //   3. Legacy entry (hostId === '') or new entry, no port: auto-assign.
     let port: number
-    if (existing !== undefined) {
-      port = existing.port
-    } else if (input.port !== null && input.port !== undefined) {
-      if (!isPortAvailable(serves, input.port)) {
+    if (input.port !== null && input.port !== undefined) {
+      // Exclude the existing entry's own port from the "in use" check so the
+      // user can re-submit without being blocked by their own port.
+      const servesWithoutThis = {
+        ...serves,
+        [packageId]: { ...(serves[packageId] ?? {}) },
+      }
+      delete servesWithoutThis[packageId][interfaceId]
+      if (!isPortAvailable(servesWithoutThis, input.port)) {
         const blocked = [...BLOCKED_PORTS].join(', ')
         throw new Error(
           `Port ${input.port} is reserved or already in use. ` +
@@ -123,6 +128,9 @@ export const addServe = sdk.Action.withInput(
         )
       }
       port = input.port
+    } else if (existing !== undefined && existing.hostId !== '') {
+      // Preserve the stored port for fully-configured existing entries.
+      port = existing.port
     } else {
       port = assignPort(serves)
     }

--- a/startos/actions/login.ts
+++ b/startos/actions/login.ts
@@ -31,7 +31,7 @@ export const getStarted = sdk.Action.withInput(
 
   // metadata
   async () => ({
-    name: 'Tailscale Login',
+    name: 'Login',
     description:
       'Provide a Tailscale auth key to login. ' +
       'Generate a new key at https://login.tailscale.com/admin/settings/keys',

--- a/startos/actions/login.ts
+++ b/startos/actions/login.ts
@@ -33,8 +33,8 @@ export const getStarted = sdk.Action.withInput(
   async () => ({
     name: 'Tailscale Login',
     description:
-      'Provide a Tailscale auth key for headless login, ' +
-      'or leave blank and open the Web UI to sign in interactively after the service starts.',
+      'Provide a Tailscale auth key to login. ' +
+      'Generate a new key at https://login.tailscale.com/admin/settings/keys',
     warning: 'Alternatively, go to Dashboard and click Open UI for interactive login.',
     allowedStatuses: 'any',
     group: null,

--- a/startos/actions/login.ts
+++ b/startos/actions/login.ts
@@ -95,18 +95,28 @@ export const getStarted = sdk.Action.withInput(
             { env: { TS_SOCKET: SOCKET, TS_AUTHKEY: authKey } },
           )
           if (loginResult.exitCode !== 0) {
-            // The key was rejected — clear it from the store so it is not
-            // retried on every subsequent restart.
-            try {
-              const s = (await storeJson.read().once()) ?? { ...storeData, authKey }
-              await storeJson.write(effects, { ...s, authKey: null })
-            } catch {}
-            throw new Error(
-              'tailscale login failed: ' +
-                (loginResult.stderr?.toString().trim() ||
-                  loginResult.stdout?.toString().trim() ||
-                  `exit code ${loginResult.exitCode}`),
-            )
+            // The key was rejected by tailscale (not a socket/connectivity
+            // error, which is caught by the outer catch).  Clear it from the
+            // store so it is not retried on every subsequent restart.
+            const errText =
+              loginResult.stderr?.toString().trim() ||
+              loginResult.stdout?.toString().trim() ||
+              `exit code ${loginResult.exitCode}`
+            // Don't clear the key for transient / socket-unavailable errors —
+            // the outer catch handles those and we want to retry on next start.
+            const isTransient =
+              errText.includes('no such file') ||
+              errText.includes('ENOENT') ||
+              errText.includes('ECONNREFUSED') ||
+              errText.includes('connect') ||
+              errText.includes('socket')
+            if (!isTransient) {
+              try {
+                const s = (await storeJson.read().once()) ?? { ...storeData, authKey }
+                await storeJson.write(effects, { ...s, authKey: null })
+              } catch {}
+            }
+            throw new Error('tailscale login failed: ' + errText)
           }
 
           const deadline = Date.now() + POLL_TIMEOUT_MS

--- a/startos/actions/setMachineName.ts
+++ b/startos/actions/setMachineName.ts
@@ -41,12 +41,9 @@ export const setMachineName = sdk.Action.withInput(
     name: 'Set Machine Name',
     description:
       'Set the hostname this node advertises on your Tailscale network. ' +
-      'Serve URLs (e.g. mynode.tail1234.ts.net:10001) update automatically ' +
-      'once Tailscale confirms the new name. ' +
+      'The name is re-applied on every restart. ' +
       'This only takes effect if "Auto-generate from OS hostname" is enabled ' +
-      '(the default) in the Tailscale admin console. If you have manually ' +
-      'renamed this machine in the admin console, that name takes precedence. ' +
-      'Must be completed before the service can start for the first time.',
+      '(the default) in the Tailscale admin console.',
     warning:
       'This action only controls the hostname sent to Tailscale via ' +
       '`tailscale set --hostname`. If you have manually renamed this machine ' +
@@ -75,9 +72,8 @@ export const setMachineName = sdk.Action.withInput(
       throw new Error('Machine name cannot be empty.')
     }
 
-    // Persist the chosen name and reset hostnameSet so the startup oneshot
-    // re-applies the name on the next start (handles both first-install and
-    // subsequent rename-while-stopped flows).
+    // Persist the chosen name — the set-hostname startup oneshot always
+    // re-applies it on every restart, so no hostnameSet flag is needed.
     const storeData = (await storeJson.read().once()) ?? {
       machineName: 'startos',
       hostnameSet: false,
@@ -88,14 +84,10 @@ export const setMachineName = sdk.Action.withInput(
     await storeJson.write(effects, {
       ...storeData,
       machineName,
-      hostnameSet: false,
     })
 
     // If the service is currently running, apply the rename immediately via a
     // shared temp subcontainer so the change takes effect without a restart.
-    // If the daemon isn't running yet (e.g. first-install, service stopped),
-    // the write above is enough — the set-hostname oneshot picks it up on
-    // the next start.
     try {
       const mounts = sdk.Mounts.of().mountVolume({
         volumeId: 'tailscale',
@@ -118,23 +110,8 @@ export const setMachineName = sdk.Action.withInput(
           ])
 
           if (r.exitCode === 0) {
-            // Re-read the latest store to avoid overwriting concurrent writes
-            // (e.g. addServe/removeServe running between our two writes).
-            const latestStoreData = (await storeJson.read().once()) ?? {
-              machineName: 'startos',
-              hostnameSet: false,
-              serves: {},
-              authKey: null,
-            }
-            // Mark applied so the startup oneshot skips the redundant set.
-            await storeJson.write(effects, {
-              ...latestStoreData,
-              machineName,
-              hostnameSet: true,
-            })
             console.info(`[set-machine-name] applied immediately: ${machineName}`)
           } else {
-            // Daemon not running — startup oneshot will apply on next start.
             console.info(
               `[set-machine-name] daemon not running (exit ${r.exitCode}), ` +
               `name saved to store; will apply on next start`,
@@ -143,7 +120,6 @@ export const setMachineName = sdk.Action.withInput(
         },
       )
     } catch (e) {
-      // Any error here means the daemon isn't running; startup oneshot handles it.
       console.info(
         '[set-machine-name] could not reach running daemon, name will be applied on next start:',
         e,

--- a/startos/actions/setMachineName.ts
+++ b/startos/actions/setMachineName.ts
@@ -38,11 +38,13 @@ export const setMachineName = sdk.Action.withInput(
 
   // metadata
   async () => ({
-    name: 'Set Machine Name',
-    description: 'Set the Tailscale machine name.',
+    name: 'Machine Name',
+    description:
+      'Set the name for your machine on your Tailscale network. ' +
+      'Determines MagicDNS URL, startos.example.ts.net.',
     warning:
       '"Auto-generate from OS hostname" must be enabled in the Tailscale ' +
-      'admin console: https://login.tailscale.com/admin/machines',
+      'admin console (default): https://login.tailscale.com/admin/machines',
     allowedStatuses: 'any',
     group: null,
     visibility: 'enabled',

--- a/startos/actions/setMachineName.ts
+++ b/startos/actions/setMachineName.ts
@@ -39,17 +39,10 @@ export const setMachineName = sdk.Action.withInput(
   // metadata
   async () => ({
     name: 'Set Machine Name',
-    description:
-      'Set the hostname this node advertises on your Tailscale network. ' +
-      'The name is re-applied on every restart. ' +
-      'This only takes effect if "Auto-generate from OS hostname" is enabled ' +
-      '(the default) in the Tailscale admin console.',
+    description: 'Set the Tailscale machine name.',
     warning:
-      'This action only controls the hostname sent to Tailscale via ' +
-      '`tailscale set --hostname`. If you have manually renamed this machine ' +
-      'in the Tailscale admin console, the admin-console name takes precedence ' +
-      'and this setting has no visible effect until you re-enable ' +
-      '"Auto-generate from OS hostname" in the admin console.',
+      '"Auto-generate from OS hostname" must be enabled in the Tailscale ' +
+      'admin console: https://login.tailscale.com/admin/machines',
     allowedStatuses: 'any',
     group: null,
     visibility: 'enabled',

--- a/startos/init/index.ts
+++ b/startos/init/index.ts
@@ -16,9 +16,8 @@ async function scheduleGetStarted(
   if (kind !== 'install') return
   await sdk.action.createOwnTask(effects, getStarted, 'important', {
     reason:
-      'Authenticate Tailscale: provide an auth key for headless login, ' +
-      'or open the Web UI to sign in interactively. ' +
-      'Generate an auth key at https://login.tailscale.com/admin/settings/keys',
+      'Provide a Tailscale auth key to login. ' +
+      'Generate a new key at https://login.tailscale.com/admin/settings/keys',
     replayId: 'get-started-first-launch',
   })
 }

--- a/startos/init/initializeService.ts
+++ b/startos/init/initializeService.ts
@@ -19,9 +19,7 @@ export const initializeService = sdk.setupOnInit(async (effects, kind) => {
   // the user can accept it immediately or pick a custom name.
   await sdk.action.createOwnTask(effects, setMachineName, 'critical', {
     reason:
-      'Set your Tailscale machine name before starting the service. ' +
-      "The default is 'startos'. Accept the default or enter a custom name. " +
-      'This only takes effect when "Auto-generate from OS hostname" is enabled ' +
-      '(the default) in the Tailscale admin console.',
+      'Set the name for your machine on your Tailscale network. ' +
+      'Determines MagicDNS URL, startos.example.ts.net.',
   })
 })

--- a/startos/interfaces.ts
+++ b/startos/interfaces.ts
@@ -10,7 +10,7 @@ export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
   const ui = sdk.createInterface(effects, {
     name: 'Web Interface',
     id: 'ui',
-    description: 'Manage your Tailscale node — login, subnet routes, exit node, and SSH',
+    description: 'Manage your Tailscale machine — login, subnet routes, exit node, and SSH',
     type: 'ui',
     masked: false,
     schemeOverride: null,

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -180,7 +180,7 @@ export const main = sdk.setupMain(async ({ effects }) => {
           // the serves will be reapplied on the next start once the node is
           // connected.
           const POLL_INTERVAL_MS = 500
-          const POLL_TIMEOUT_MS = 30_000
+          const POLL_TIMEOUT_MS = 10_000
           const deadline = Date.now() + POLL_TIMEOUT_MS
 
           let reachedRunning = false

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -223,21 +223,14 @@ export const main = sdk.setupMain(async ({ effects }) => {
       subcontainer,
       exec: {
         fn: async () => {
-          // Apply the user-chosen machine name via `tailscale set --hostname`.
-          // We do this once per first-connect (hostnameSet === false) and skip
-          // on subsequent restarts to avoid overwriting admin-console renames.
-          // If the user re-runs the Set Machine Name action while stopped, it
-          // resets hostnameSet to false, causing this oneshot to re-apply.
+          // Always apply the user-chosen machine name via `tailscale set --hostname`
+          // on every start.  The stored machineName is the source of truth; Tailscale
+          // appends "-1"/"-N" automatically if the name conflicts with another node.
           const storeData = (await storeJson.read().once()) ?? {
             machineName: 'startos',
             hostnameSet: false,
             serves: {},
             authKey: null,
-          }
-
-          if (storeData.hostnameSet) {
-            console.info('[set-hostname] hostname already set, skipping')
-            return null
           }
 
           const name = storeData.machineName ?? 'startos'
@@ -256,7 +249,6 @@ export const main = sdk.setupMain(async ({ effects }) => {
             )
           }
 
-          await storeJson.write(effects, { ...storeData, hostnameSet: true })
           console.info(`[set-hostname] hostname set to: ${name}`)
           return null
         },

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -172,16 +172,18 @@ export const main = sdk.setupMain(async ({ effects }) => {
       subcontainer,
       exec: {
         fn: async () => {
-          // The tailscaled ready check returns as soon as the socket is alive
-          // (BackendState may still be NoState/Starting) so the web UI can
-          // unblock for fresh installs in NeedsLogin. Serve commands, however,
-          // require a populated netMap — issuing `tailscale serve reset`
-          // before the control-plane handshake completes fails with
-          // "netMap is nil". Poll BackendState here so the restore is silent.
+          // Serve commands require a populated netMap.  `tailscale serve reset`
+          // fails with "netMap is nil" for any BackendState other than Running
+          // (including NeedsLogin, which has no control-plane connection yet).
+          // Poll until Running or timeout — if we never reach Running (e.g.
+          // fresh install still waiting for auth), skip the restore entirely;
+          // the serves will be reapplied on the next start once the node is
+          // connected.
           const POLL_INTERVAL_MS = 500
           const POLL_TIMEOUT_MS = 30_000
           const deadline = Date.now() + POLL_TIMEOUT_MS
 
+          let reachedRunning = false
           while (Date.now() < deadline) {
             const r = await subcontainer.exec([
               'tailscale',
@@ -195,15 +197,20 @@ export const main = sdk.setupMain(async ({ effects }) => {
                 st = JSON.parse(r.stdout.toString())
               } catch {}
               const state = st.BackendState ?? ''
-              if (state !== '' && state !== 'NoState' && state !== 'Starting') break
+              if (state === 'Running') {
+                reachedRunning = true
+                break
+              }
             }
             await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
           }
 
-          if (Date.now() >= deadline) {
-            console.warn(
-              '[restore-serves] timed out waiting for tailscaled BackendState; proceeding anyway',
+          if (!reachedRunning) {
+            console.info(
+              '[restore-serves] BackendState never reached Running within timeout ' +
+              '(node may need login); skipping serve restore — will retry on next start',
             )
+            return null
           }
 
           const storeData = (await storeJson.read().once()) ?? {

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -36,6 +36,8 @@ export const main = sdk.setupMain(async ({ effects }) => {
   const pendingAuthKey = initialStore.authKey ?? null
   if (pendingAuthKey) {
     console.info('[main] Pending auth key found; will apply via tailscale login once daemon is ready.')
+  } else {
+    console.info('[main] No pending auth key in store.')
   }
 
   // Tracks whether we have already triggered the headless login for this


### PR DESCRIPTION
Closes #18

## Summary

- **Machine name reset on restart**: The `hostnameSet` flag caused the machine name to revert to `startos` when the flag was stale (e.g. after reinstall or schema migration). Removed the skip guard — `set-hostname` oneshot now always re-applies the stored `machineName` on every restart. Tailscale handles name conflicts by appending `-1`/`-N` automatically.

- **addServe blocked on previously-configured interface**: When `store.json` survives an uninstall/reinstall cycle the old serve entry caused `addServe` to bail out with "already configured — skipping", even though tailscaled's serve config had been reset. Removed the early-return skip so re-running `add-serve` always re-applies (or updates) the serve. Port-selection logic updated: an explicit port now updates even existing entries (excluding the entry's own port from the conflict check); omitting the port preserves the stored port for fully-configured entries.

- **Auth key cleared before use on fresh install**: When `get-started` runs while the container is stopped, `SubContainer.withTemp` creates a temp container but `tailscale login` exits non-zero because the tailscaled socket doesn't exist. The old code unconditionally cleared `authKey` from the store on any non-zero exit, so the key was gone by the time `main.ts` read the store on the next start — causing `BackendState: NeedsLogin` to persist with no login attempt. Fixed by checking the error output for socket/connectivity indicators before clearing; only genuine auth rejections (bad/expired key) clear the stored key.

- **Misc**: fix missing space in `setMachineName` warning; update action description; add `[main] No pending auth key in store` log line.