### PR TITLE
feat: Taildrop receive support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ expose other StartOS services to your tailnet via `tailscale serve`.
 | Image         | `ghcr.io/tailscale/tailscale:v1.96.5` |
 | File Browser  | `filebrowser/filebrowser:v2.63.2`  |
 | Architectures | x86_64, aarch64                    |
-| Runtime       | Three daemons across two subcontainers |
+| Runtime       | Four daemons across two subcontainers |
 
-Three daemons across two subcontainers (the Tailscale subcontainer uses `sharedRun: true` so that action temp containers can reach the tailscaled Unix socket):
+Four daemons across two subcontainers (the Tailscale subcontainer uses `sharedRun: true` so that action temp containers can reach the tailscaled Unix socket):
 
 1. **`tailscaled`** — the Tailscale daemon, running in userspace networking mode
 2. **`tailscale-web`** — runs `tailscale web --listen=0.0.0.0:8080`, exposing the management UI
@@ -63,6 +63,7 @@ Three daemons across two subcontainers (the Tailscale subcontainer uses `sharedR
 | `tailscale` | `/var/lib/tailscale`  | Persistent daemon state and identity           |
 | `startos`   | (JS runtime)          | Serve port mappings (`store.json`), cached Tailscale IP/DNS (`status.json`) |
 | `taildrop`  | `/taildrop`           | Files received via Taildrop (user-visible)     |
+| `filebrowser-config` | `/config`    | Filebrowser persistent configuration (database) |
 
 **Key files:**
 
@@ -324,6 +325,7 @@ volumes:
   tailscale: /var/lib/tailscale       # daemon state
   startos: (js runtime)               # store.json, status.json
   taildrop: /taildrop                 # received Taildrop files (read-write for taildrop-receive, read-only for taildrop-files)
+  filebrowser-config: /config         # filebrowser persistent configuration (database)
 ports:
   8080: Tailscale web interface (HTTP)
   8081: Taildrop file browser (HTTP, no auth)
@@ -358,10 +360,10 @@ daemons:
       If not logged in, the daemon exits and restarts; ready check returns loading until connected.
   - id: taildrop-files
     image: filebrowser/filebrowser:v2.63.2
-    command: filebrowser --noauth --root=/taildrop --address=0.0.0.0 --port=8081 --database=/dev/null
+    command: filebrowser --noauth --address=0.0.0.0 --port=8081 --database=/config/filebrowser.db
     health: port 8081 listening
-    requires: []
-    notes: Read-only view of the taildrop volume. No authentication required.
+    requires: [chown-filebrowser-config]
+    notes: Read-only view of the taildrop volume (mounted at /srv). No authentication required.
 actions:
   - id: add-serve   # exposed via URL plugin table action
     description: Assign a tailnet port and configure tailscale serve for a service interface

--- a/README.md
+++ b/README.md
@@ -41,17 +41,18 @@ expose other StartOS services to your tailnet via `tailscale serve`.
 | Property      | Value                              |
 | ------------- | ---------------------------------- |
 | Image         | `ghcr.io/tailscale/tailscale:v1.96.5` |
+| File Browser  | `filebrowser/filebrowser:v2.63.2`  |
 | Architectures | x86_64, aarch64                    |
-| Runtime       | Two daemons in one subcontainer    |
+| Runtime       | Three daemons across two subcontainers |
 
-Three daemons share a single subcontainer (with `sharedRun: true` so that action
-temp containers can reach the tailscaled Unix socket):
+Three daemons across two subcontainers (the Tailscale subcontainer uses `sharedRun: true` so that action temp containers can reach the tailscaled Unix socket):
 
 1. **`tailscaled`** — the Tailscale daemon, running in userspace networking mode
 2. **`tailscale-web`** — runs `tailscale web --listen=0.0.0.0:8080`, exposing the management UI
 3. **`taildrop-receive`** — runs `tailscale file get --loop /taildrop`, saving incoming Taildrop files to the `taildrop` volume
+4. **`taildrop-files`** — runs `filebrowser --noauth --root=/taildrop` on port 8081, exposing a web UI to browse and download received files
 
-`tailscale-web` and `taildrop-receive` both start only after `tailscaled` and `set-hostname` are ready.
+`tailscale-web` and `taildrop-receive` both start only after `tailscaled` and `set-hostname` are ready. `taildrop-files` starts independently in its own subcontainer.
 
 ---
 
@@ -107,7 +108,7 @@ All Tailscale configuration is managed through the **Tailscale web interface**
 | Subnet router       | Web UI → Settings → Subnet router         |
 | Exit node           | Web UI → This device → Exit node          |
 | Tailscale SSH       | Web UI → Settings → Tailscale SSH server  |
-| Logout / re-auth    | Web UI → Settings → Log out               |
+| Taildrop files      | Service Interfaces → Taildrop Files   |
 | Expose services     | URL plugin → Add Serve (tile action)      |
 
 ### Daemon environment
@@ -127,6 +128,7 @@ The daemon is started with the following fixed arguments:
 | Interface | Type   | Port | Description                               |
 | --------- | ------ | ---- | ----------------------------------------- |
 | `ui`      | Web UI | 8080 | Tailscale device management web interface |
+| `taildrop-files` | Web UI | 8081 | Browse and download files received via Taildrop |
 
 The Tailscale web interface is accessible over LAN and Tor via the standard
 StartOS interface mechanism on port 8080.
@@ -258,11 +260,12 @@ metadata — the existing tailnet port is preserved.
 
 ## Health Checks
 
-| Check              | Display Name       | Method                                    |
-| ------------------ | ------------------ | ----------------------------------------- |
-| `tailscaled`       | Tailscale Daemon   | `tailscale status --json` exits 0         |
-| `tailscale-web`    | Web Interface      | TCP port 8080 is listening                |
-| `taildrop-receive` | Taildrop Receive   | `tailscale status --json` BackendState === 'Running' |
+| Check              | Display Name          | Method                                    |
+| ------------------ | --------------------- | ----------------------------------------- |
+| `tailscaled`       | Tailscale Daemon      | `tailscale status --json` exits 0         |
+| `tailscale-web`    | Web Interface         | TCP port 8080 is listening                |
+| `taildrop-receive` | Taildrop Receive      | `tailscale status --json` BackendState === 'Running' |
+| `taildrop-files`   | Taildrop File Browser | TCP port 8081 is listening                |
 
 On each successful `tailscaled` health check, the node's Tailscale IP and
 MagicDNS name are written to `startos/status.json`.  Once `tailscaled` is
@@ -320,9 +323,10 @@ architectures: [x86_64, aarch64]
 volumes:
   tailscale: /var/lib/tailscale       # daemon state
   startos: (js runtime)               # store.json, status.json
-  taildrop: /taildrop                 # received Taildrop files
+  taildrop: /taildrop                 # received Taildrop files (read-write for taildrop-receive, read-only for taildrop-files)
 ports:
   8080: Tailscale web interface (HTTP)
+  8081: Taildrop file browser (HTTP, no auth)
 dependencies: none
 daemons:
   - id: tailscaled
@@ -352,6 +356,12 @@ daemons:
       Node must be logged in as a personal (non-tagged) device.
       Send Files must be enabled in the Tailscale admin console.
       If not logged in, the daemon exits and restarts; ready check returns loading until connected.
+  - id: taildrop-files
+    image: filebrowser/filebrowser:v2.63.2
+    command: filebrowser --noauth --root=/taildrop --address=0.0.0.0 --port=8081 --database=/dev/null
+    health: port 8081 listening
+    requires: []
+    notes: Read-only view of the taildrop volume. No authentication required.
 actions:
   - id: add-serve   # exposed via URL plugin table action
     description: Assign a tailnet port and configure tailscale serve for a service interface

--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ expose other StartOS services to your tailnet via `tailscale serve`.
 | Architectures | x86_64, aarch64                    |
 | Runtime       | Two daemons in one subcontainer    |
 
-Two daemons share a single subcontainer (with `sharedRun: true` so that action
+Three daemons share a single subcontainer (with `sharedRun: true` so that action
 temp containers can reach the tailscaled Unix socket):
 
 1. **`tailscaled`** — the Tailscale daemon, running in userspace networking mode
 2. **`tailscale-web`** — runs `tailscale web --listen=0.0.0.0:8080`, exposing the management UI
+3. **`taildrop-receive`** — runs `tailscale file get --loop /taildrop`, saving incoming Taildrop files to the `taildrop` volume
 
-`tailscale-web` starts only after `tailscaled` is ready.
+`tailscale-web` and `taildrop-receive` both start only after `tailscaled` and `set-hostname` are ready.
 
 ---
 
@@ -60,6 +61,7 @@ temp containers can reach the tailscaled Unix socket):
 | ----------- | --------------------- | ---------------------------------------------- |
 | `tailscale` | `/var/lib/tailscale`  | Persistent daemon state and identity           |
 | `startos`   | (JS runtime)          | Serve port mappings (`store.json`), cached Tailscale IP/DNS (`status.json`) |
+| `taildrop`  | `/taildrop`           | Files received via Taildrop (user-visible)     |
 
 **Key files:**
 
@@ -256,10 +258,11 @@ metadata — the existing tailnet port is preserved.
 
 ## Health Checks
 
-| Check           | Display Name     | Method                                    |
-| --------------- | ---------------- | ----------------------------------------- |
-| `tailscaled`    | Tailscale Daemon | `tailscale status --json` exits 0         |
-| `tailscale-web` | Web Interface    | TCP port 8080 is listening                |
+| Check              | Display Name       | Method                                    |
+| ------------------ | ------------------ | ----------------------------------------- |
+| `tailscaled`       | Tailscale Daemon   | `tailscale status --json` exits 0         |
+| `tailscale-web`    | Web Interface      | TCP port 8080 is listening                |
+| `taildrop-receive` | Taildrop Receive   | `tailscale status --json` BackendState === 'Running' |
 
 On each successful `tailscaled` health check, the node's Tailscale IP and
 MagicDNS name are written to `startos/status.json`.  Once `tailscaled` is
@@ -280,7 +283,7 @@ None. Tailscale is a standalone service.
    routing for other containers requires SOCKS5 or HTTP proxy configuration.
 2. **No CLI access** — interact only through the web interface or StartOS
    actions; the `tailscale` CLI is not exposed to the StartOS user directly.
-3. **No Taildrop** — file transfer via Taildrop is not tested and not supported.
+3. **No Taildrop send** — Taildrop file *receive* is supported (files are saved to the `taildrop` volume). Sending files from StartOS to other devices is not supported. Tagged nodes are excluded by Tailscale — the device must be logged in as a personal (non-tagged) account for Taildrop to work. The **Send Files** feature must also be enabled in the [Tailscale admin console](https://login.tailscale.com/admin/settings/features). Taildrop is still in public alpha.
 4. **HTTPS reverse proxy for HTTP services** — `tailscale serve --bg --https`
    is used for HTTP backends; Tailscale terminates TLS so clients access
    services over `https://`. Non-HTTP services use raw TCP forwarding.
@@ -317,6 +320,7 @@ architectures: [x86_64, aarch64]
 volumes:
   tailscale: /var/lib/tailscale       # daemon state
   startos: (js runtime)               # store.json, status.json
+  taildrop: /taildrop                 # received Taildrop files
 ports:
   8080: Tailscale web interface (HTTP)
 dependencies: none
@@ -338,7 +342,16 @@ daemons:
   - id: tailscale-web
     command: tailscale web --listen=0.0.0.0:8080
     health: port 8080 listening
-    requires: [tailscaled, restore-serves]
+    requires: [tailscaled, set-hostname]
+  - id: taildrop-receive
+    command: tailscale file get --loop /taildrop
+    health: tailscale status --json, BackendState=Running
+    requires: [set-hostname]
+    notes: |
+      Saves incoming Taildrop files to the taildrop volume (/taildrop).
+      Node must be logged in as a personal (non-tagged) device.
+      Send Files must be enabled in the Tailscale admin console.
+      If not logged in, the daemon exits and restarts; ready check returns loading until connected.
 actions:
   - id: add-serve   # exposed via URL plugin table action
     description: Assign a tailnet port and configure tailscale serve for a service interface

--- a/startos/constants.ts
+++ b/startos/constants.ts
@@ -1,2 +1,5 @@
 /** Port the Tailscale web UI listens on. */
 export const UI_PORT = 8080
+
+/** Port the Taildrop file browser listens on. */
+export const FILEBROWSER_PORT = 8081

--- a/startos/interfaces.ts
+++ b/startos/interfaces.ts
@@ -1,8 +1,9 @@
 import { sdk } from './sdk'
+import { FILEBROWSER_PORT } from './constants'
 
 export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
-  const multi = sdk.MultiHost.of(effects, 'ui')
-  const origin = await multi.bindPort(8080, {
+  const uiMulti = sdk.MultiHost.of(effects, 'ui')
+  const uiOrigin = await uiMulti.bindPort(8080, {
     protocol: 'http',
     preferredExternalPort: 8080,
   })
@@ -19,5 +20,26 @@ export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
     query: {},
   })
 
-  return [await origin.export([ui])]
+  const fileBrowserMulti = sdk.MultiHost.of(effects, 'taildrop-files')
+  const fileBrowserOrigin = await fileBrowserMulti.bindPort(FILEBROWSER_PORT, {
+    protocol: 'http',
+    preferredExternalPort: FILEBROWSER_PORT,
+  })
+
+  const fileBrowser = sdk.createInterface(effects, {
+    name: 'Taildrop Files',
+    id: 'taildrop-files',
+    description: 'Browse and download files received via Taildrop',
+    type: 'ui',
+    masked: false,
+    schemeOverride: null,
+    username: null,
+    path: '',
+    query: {},
+  })
+
+  return [
+    await uiOrigin.export([ui]),
+    await fileBrowserOrigin.export([fileBrowser]),
+  ]
 })

--- a/startos/interfaces.ts
+++ b/startos/interfaces.ts
@@ -1,11 +1,11 @@
 import { sdk } from './sdk'
-import { FILEBROWSER_PORT } from './constants'
+import { UI_PORT, FILEBROWSER_PORT } from './constants'
 
 export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
   const uiMulti = sdk.MultiHost.of(effects, 'ui')
-  const uiOrigin = await uiMulti.bindPort(8080, {
+  const uiOrigin = await uiMulti.bindPort(UI_PORT, {
     protocol: 'http',
-    preferredExternalPort: 8080,
+    preferredExternalPort: UI_PORT,
   })
 
   const ui = sdk.createInterface(effects, {

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -3,7 +3,7 @@ import { statusJson } from './fileModels/status.json'
 import { storeJson } from './fileModels/store.json'
 import { parseTailscaleIp, parseDnsName } from './utils'
 import { applyServicesConfig } from './serves'
-import { UI_PORT } from './constants'
+import { UI_PORT, FILEBROWSER_PORT } from './constants'
 const STATE_DIR = '/var/lib/tailscale'
 const SOCKET = '/var/run/tailscale/tailscaled.sock'
 
@@ -29,6 +29,20 @@ export const main = sdk.setupMain(async ({ effects }) => {
     { imageId: 'tailscale', sharedRun: true },
     mounts,
     'tailscale-sub',
+  )
+
+  const fileBrowserMounts = sdk.Mounts.of().mountVolume({
+    volumeId: 'taildrop',
+    subpath: null,
+    mountpoint: '/taildrop',
+    readonly: true,
+  })
+
+  const fileBrowserSubcontainer = await sdk.SubContainer.of(
+    effects,
+    { imageId: 'filebrowser' },
+    fileBrowserMounts,
+    'filebrowser-sub',
   )
 
   // Read any pending auth key saved by the Get Started action while the
@@ -337,5 +351,27 @@ export const main = sdk.setupMain(async ({ effects }) => {
         gracePeriod: 10_000,
       },
       requires: ['set-hostname'],
+    })
+    .addDaemon('taildrop-files', {
+      subcontainer: fileBrowserSubcontainer,
+      exec: {
+        command: [
+          '/filebrowser',
+          '--noauth',
+          '--root=/taildrop',
+          '--address=0.0.0.0',
+          '--port=' + FILEBROWSER_PORT,
+          '--database=/dev/null',
+        ],
+      },
+      ready: {
+        display: 'Taildrop File Browser',
+        fn: () =>
+          sdk.healthCheck.checkPortListening(effects, FILEBROWSER_PORT, {
+            successMessage: 'The file browser is ready',
+            errorMessage: 'The file browser is not yet ready',
+          }),
+      },
+      requires: [],
     })
 })

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -362,7 +362,7 @@ export const main = sdk.setupMain(async ({ effects }) => {
     .addOneshot('chown-filebrowser-config', {
       subcontainer: fileBrowserSubcontainer,
       exec: {
-        command: ['chown', '-R', 'user:user', '/srv', '/config'],
+        command: ['chown', '-R', 'user:user', '/config'],
         user: 'root',
       },
       requires: [],

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -35,12 +35,12 @@ export const main = sdk.setupMain(async ({ effects }) => {
     .mountVolume({
       volumeId: 'taildrop',
       subpath: null,
-      mountpoint: '/taildrop',
+      mountpoint: '/srv',
       readonly: true,
     })
     .mountVolume({
-      volumeId: 'startos',
-      subpath: 'filebrowser',
+      volumeId: 'filebrowser-config',
+      subpath: null,
       mountpoint: '/config',
       readonly: false,
     })
@@ -362,39 +362,31 @@ export const main = sdk.setupMain(async ({ effects }) => {
     .addOneshot('chown-filebrowser-config', {
       subcontainer: fileBrowserSubcontainer,
       exec: {
-        fn: async () => {
-          console.info('[chown-filebrowser-config] fixing ownership of /config for uid/gid 1000')
-          const r = await fileBrowserSubcontainer.exec(['chown', '-R', '1000:1000', '/config'])
-          if (r.exitCode !== 0) {
-            throw new Error(
-              `[chown-filebrowser-config] chown failed: ${r.stderr?.toString().trim() || r.stdout?.toString().trim() || `exit code ${r.exitCode}`}`,
-            )
-          }
-          console.info('[chown-filebrowser-config] /config ownership fixed')
-          return null
-        },
+        command: ['chown', '-R', 'user:user', '/srv', '/config'],
+        user: 'root',
       },
       requires: [],
     })
     .addDaemon('taildrop-files', {
       subcontainer: fileBrowserSubcontainer,
       exec: {
-        command: [
-          '/bin/filebrowser',
+        command: sdk.useEntrypoint([
           '--noauth',
-          '--root=/taildrop',
-          '--address=0.0.0.0',
           '--port=' + FILEBROWSER_PORT,
           '--database=/config/filebrowser.db',
-        ],
+        ]),
       },
       ready: {
         display: 'Taildrop File Browser',
         fn: () =>
-          sdk.healthCheck.checkPortListening(effects, FILEBROWSER_PORT, {
-            successMessage: 'The file browser is ready',
-            errorMessage: 'The file browser is not yet ready',
-          }),
+          sdk.healthCheck.checkWebUrl(
+            effects,
+            `http://localhost:${FILEBROWSER_PORT}/health`,
+            {
+              successMessage: 'The file browser is ready',
+              errorMessage: 'The file browser is not yet ready',
+            },
+          ),
       },
       requires: ['chown-filebrowser-config'],
     })

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -359,23 +359,6 @@ export const main = sdk.setupMain(async ({ effects }) => {
       },
       requires: ['set-hostname'],
     })
-    .addOneshot('chown-filebrowser-config', {
-      subcontainer: fileBrowserSubcontainer,
-      exec: {
-        fn: async () => {
-          console.info('[chown-filebrowser-config] fixing ownership of /config for uid/gid 1000')
-          const r = await fileBrowserSubcontainer.exec(['chown', '-R', '1000:1000', '/config'])
-          if (r.exitCode !== 0) {
-            throw new Error(
-              `[chown-filebrowser-config] chown failed: ${r.stderr?.toString().trim() || r.stdout?.toString().trim() || `exit code ${r.exitCode}`}`,
-            )
-          }
-          console.info('[chown-filebrowser-config] /config ownership fixed')
-          return null
-        },
-      },
-      requires: [],
-    })
     .addDaemon('taildrop-files', {
       subcontainer: fileBrowserSubcontainer,
       exec: {
@@ -387,6 +370,7 @@ export const main = sdk.setupMain(async ({ effects }) => {
           '--port=' + FILEBROWSER_PORT,
           '--database=/config/filebrowser.db',
         ],
+        user: 'user',
       },
       ready: {
         display: 'Taildrop File Browser',
@@ -396,6 +380,6 @@ export const main = sdk.setupMain(async ({ effects }) => {
             errorMessage: 'The file browser is not yet ready',
           }),
       },
-      requires: ['chown-filebrowser-config'],
+      requires: [],
     })
 })

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -359,6 +359,23 @@ export const main = sdk.setupMain(async ({ effects }) => {
       },
       requires: ['set-hostname'],
     })
+    .addOneshot('chown-filebrowser-config', {
+      subcontainer: fileBrowserSubcontainer,
+      exec: {
+        fn: async () => {
+          console.info('[chown-filebrowser-config] fixing ownership of /config for uid/gid 1000')
+          const r = await fileBrowserSubcontainer.exec(['chown', '-R', '1000:1000', '/config'])
+          if (r.exitCode !== 0) {
+            throw new Error(
+              `[chown-filebrowser-config] chown failed: ${r.stderr?.toString().trim() || r.stdout?.toString().trim() || `exit code ${r.exitCode}`}`,
+            )
+          }
+          console.info('[chown-filebrowser-config] /config ownership fixed')
+          return null
+        },
+      },
+      requires: [],
+    })
     .addDaemon('taildrop-files', {
       subcontainer: fileBrowserSubcontainer,
       exec: {
@@ -370,7 +387,6 @@ export const main = sdk.setupMain(async ({ effects }) => {
           '--port=' + FILEBROWSER_PORT,
           '--database=/config/filebrowser.db',
         ],
-        user: 'user',
       },
       ready: {
         display: 'Taildrop File Browser',
@@ -380,6 +396,6 @@ export const main = sdk.setupMain(async ({ effects }) => {
             errorMessage: 'The file browser is not yet ready',
           }),
       },
-      requires: [],
+      requires: ['chown-filebrowser-config'],
     })
 })

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -359,6 +359,23 @@ export const main = sdk.setupMain(async ({ effects }) => {
       },
       requires: ['set-hostname'],
     })
+    .addOneshot('chown-filebrowser-config', {
+      subcontainer: fileBrowserSubcontainer,
+      exec: {
+        fn: async () => {
+          console.info('[chown-filebrowser-config] fixing ownership of /config for uid/gid 1000')
+          const r = await fileBrowserSubcontainer.exec(['chown', '-R', '1000:1000', '/config'])
+          if (r.exitCode !== 0) {
+            throw new Error(
+              `[chown-filebrowser-config] chown failed: ${r.stderr?.toString().trim() || r.stdout?.toString().trim() || `exit code ${r.exitCode}`}`,
+            )
+          }
+          console.info('[chown-filebrowser-config] /config ownership fixed')
+          return null
+        },
+      },
+      requires: [],
+    })
     .addDaemon('taildrop-files', {
       subcontainer: fileBrowserSubcontainer,
       exec: {
@@ -379,6 +396,6 @@ export const main = sdk.setupMain(async ({ effects }) => {
             errorMessage: 'The file browser is not yet ready',
           }),
       },
-      requires: [],
+      requires: ['chown-filebrowser-config'],
     })
 })

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -31,12 +31,19 @@ export const main = sdk.setupMain(async ({ effects }) => {
     'tailscale-sub',
   )
 
-  const fileBrowserMounts = sdk.Mounts.of().mountVolume({
-    volumeId: 'taildrop',
-    subpath: null,
-    mountpoint: '/taildrop',
-    readonly: true,
-  })
+  const fileBrowserMounts = sdk.Mounts.of()
+    .mountVolume({
+      volumeId: 'taildrop',
+      subpath: null,
+      mountpoint: '/taildrop',
+      readonly: true,
+    })
+    .mountVolume({
+      volumeId: 'startos',
+      subpath: 'filebrowser',
+      mountpoint: '/config',
+      readonly: false,
+    })
 
   const fileBrowserSubcontainer = await sdk.SubContainer.of(
     effects,
@@ -356,12 +363,12 @@ export const main = sdk.setupMain(async ({ effects }) => {
       subcontainer: fileBrowserSubcontainer,
       exec: {
         command: [
-          '/filebrowser',
+          '/bin/filebrowser',
           '--noauth',
           '--root=/taildrop',
           '--address=0.0.0.0',
           '--port=' + FILEBROWSER_PORT,
-          '--database=/dev/null',
+          '--database=/config/filebrowser.db',
         ],
       },
       ready: {

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -10,12 +10,19 @@ const SOCKET = '/var/run/tailscale/tailscaled.sock'
 export const main = sdk.setupMain(async ({ effects }) => {
   console.info('Starting Tailscale!')
 
-  const mounts = sdk.Mounts.of().mountVolume({
-    volumeId: 'tailscale',
-    subpath: null,
-    mountpoint: STATE_DIR,
-    readonly: false,
-  })
+  const mounts = sdk.Mounts.of()
+    .mountVolume({
+      volumeId: 'tailscale',
+      subpath: null,
+      mountpoint: STATE_DIR,
+      readonly: false,
+    })
+    .mountVolume({
+      volumeId: 'taildrop',
+      subpath: null,
+      mountpoint: '/taildrop',
+      readonly: false,
+    })
 
   const subcontainer = await sdk.SubContainer.of(
     effects,
@@ -283,5 +290,52 @@ export const main = sdk.setupMain(async ({ effects }) => {
           }),
       },
       requires: ['tailscaled', 'set-hostname'],
+    })
+    .addDaemon('taildrop-receive', {
+      subcontainer,
+      exec: {
+        command: [
+          'tailscale',
+          '--socket=' + SOCKET,
+          'file',
+          'get',
+          '--loop',
+          '/taildrop',
+        ],
+      },
+      ready: {
+        display: 'Taildrop Receive',
+        fn: async () => {
+          const result = await subcontainer.exec([
+            'tailscale',
+            '--socket=' + SOCKET,
+            'status',
+            '--json',
+          ])
+          if (result.exitCode !== 0) {
+            return {
+              result: 'loading',
+              message: 'Waiting for Tailscale daemon...',
+            }
+          }
+          let statusData: { BackendState?: string } = {}
+          try {
+            statusData = JSON.parse(result.stdout.toString().trim())
+          } catch {}
+          const backendState = statusData.BackendState ?? 'unknown'
+          if (backendState !== 'Running') {
+            return {
+              result: 'loading',
+              message: `Waiting for Tailscale to connect (${backendState})...`,
+            }
+          }
+          return {
+            result: 'success',
+            message: 'Ready to receive files via Taildrop',
+          }
+        },
+        gracePeriod: 10_000,
+      },
+      requires: ['set-hostname'],
     })
 })

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -11,7 +11,7 @@ export const manifest = setupManifest({
   donationUrl: null,
   docsUrls: ['https://tailscale.com/docs/'],
   description: i18n.description,
-  volumes: ['tailscale', 'startos', 'taildrop'],
+  volumes: ['tailscale', 'startos', 'taildrop', 'filebrowser-config'],
   images: {
     tailscale: {
       source: { dockerTag: 'ghcr.io/tailscale/tailscale:v1.96.5' },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -17,6 +17,10 @@ export const manifest = setupManifest({
       source: { dockerTag: 'ghcr.io/tailscale/tailscale:v1.96.5' },
       arch: ['x86_64', 'aarch64'],
     },
+    filebrowser: {
+      source: { dockerTag: 'filebrowser/filebrowser:v2.63.2' },
+      arch: ['x86_64', 'aarch64'],
+    },
   },
   dependencies: {},
   plugins: ['url-v0'],

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -11,7 +11,7 @@ export const manifest = setupManifest({
   donationUrl: null,
   docsUrls: ['https://tailscale.com/docs/'],
   description: i18n.description,
-  volumes: ['tailscale', 'startos'],
+  volumes: ['tailscale', 'startos', 'taildrop'],
   images: {
     tailscale: {
       source: { dockerTag: 'ghcr.io/tailscale/tailscale:v1.96.5' },


### PR DESCRIPTION
Closes #21

## Summary

- Add a dedicated `taildrop` volume for received files
- Add a `taildrop-receive` daemon that runs `tailscale file get --loop`
- Add a `filebrowser` image (filebrowser/filebrowser:v2.63.2) and a `filebrowser-config` volume for its persistent database
- Add a `taildrop-files` daemon (filebrowser in --noauth mode) that exposes a web UI on port 8081 for browsing and downloading received files
- Update README and Quick Reference to document all new daemons, volumes, and interfaces

## Implementation

### `startos/manifest/index.ts`
- Add `'taildrop'` and `'filebrowser-config'` to the `volumes` array
- Add `filebrowser` image entry pointing to `filebrowser/filebrowser:v2.63.2`

### `startos/main.ts`
1. Mount `taildrop` at `/taildrop` (read-write) in the Tailscale subcontainer
2. Add `taildrop-receive` daemon: `tailscale file get --loop /taildrop`; ready check polls `BackendState`; requires `set-hostname`
3. Create a second subcontainer (`filebrowser-sub`) with `taildrop` mounted read-only at `/srv` and `filebrowser-config` at `/config`
4. Add `chown-filebrowser-config` oneshot: `chown -R user:user /config` (root user, runs before filebrowser starts)
5. Add `taildrop-files` daemon: filebrowser with `--noauth --port=8081 --database=/config/filebrowser.db`; requires `chown-filebrowser-config`

### `startos/interfaces.ts`
- Add `taildrop-files` interface bound to port 8081
- Use `UI_PORT` constant for the existing UI binding (no hardcoded 8080)

### `README.md`
- Document filebrowser image, four daemons, both new volumes, and the Taildrop Files interface

## Constraints

- Taildrop is alpha — the **Send Files** toggle must be enabled per tailnet in the admin console
- Only works for personal (non-tagged) devices
- Receive only — sending files via a StartOS action is out of scope
- filebrowser runs `--noauth`; the interface is accessible to anyone who can reach the StartOS endpoint