### PR TITLE
feat: add Tailscale Funnel support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,8 @@ jobs:
 
       - name: Install start-cli
         run: |
-          LATEST=$(curl -s https://api.github.com/repos/Start9Labs/start-os/releases/latest | jq -r .tag_name)
-          curl -fsSL "https://github.com/Start9Labs/start-os/releases/download/${LATEST}/start-cli_x86_64-linux" -o /usr/local/bin/start-cli
+          START_CLI_VERSION=v0.4.0-beta.9
+          curl -fsSL "https://github.com/Start9Labs/start-os/releases/download/${START_CLI_VERSION}/start-cli_x86_64-linux" -o /usr/local/bin/start-cli
           chmod +x /usr/local/bin/start-cli
 
       - name: Initialize developer key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
 
       - name: Install start-cli
         run: |
-          LATEST=$(curl -s https://api.github.com/repos/Start9Labs/start-os/releases/latest | jq -r .tag_name)
-          curl -fsSL "https://github.com/Start9Labs/start-os/releases/download/${LATEST}/start-cli_x86_64-linux" -o /usr/local/bin/start-cli
+          START_CLI_VERSION=v0.4.0-beta.9
+          curl -fsSL "https://github.com/Start9Labs/start-os/releases/download/${START_CLI_VERSION}/start-cli_x86_64-linux" -o /usr/local/bin/start-cli
           chmod +x /usr/local/bin/start-cli
 
       - name: Initialize developer key

--- a/startos/actions/addServe.ts
+++ b/startos/actions/addServe.ts
@@ -1,10 +1,25 @@
 import { servesShape, storeJson } from '../fileModels/store.json'
 import { applyServicesConfig } from '../serves'
 import { sdk } from '../sdk'
-import { assignPort, isPortAvailable, BLOCKED_PORTS } from '../utils'
+import {
+  assignFunnelPort,
+  assignPort,
+  assertFunnelPort,
+  FUNNEL_ALLOWED_PORTS,
+  isPortAvailable,
+  BLOCKED_PORTS,
+} from '../utils'
 import { z } from '@start9labs/start-sdk'
 
 const STATE_DIR = '/var/lib/tailscale'
+
+const FUNNEL_WARNING =
+  'While Tailscale aims to preserve privacy, exposing services to the ' +
+  'public internet inherently carries risks similar to port forwarding, ' +
+  'such as exposure to automated bots or vulnerabilities in the hosted ' +
+  'application itself. ' +
+  'Learn how Funnel works before proceeding: ' +
+  'https://tailscale.com/docs/features/tailscale-funnel#how-funnel-works'
 
 const { InputSpec, Value } = sdk
 
@@ -15,10 +30,31 @@ const inputSpec = InputSpec.of({
     hostId: string
     internalPort: number
   }>(),
+  mode: Value.select({
+    name: 'Serve Mode',
+    description:
+      'Tailscale Serve shares this interface only within your private tailnet. ' +
+      'Funnel publishes it on the PUBLIC INTERNET under your node\'s MagicDNS ' +
+      'name — Tailscale manages the TLS certificate, but anyone on the internet ' +
+      'can reach the service.\n\n' +
+      'While Tailscale aims to preserve privacy, exposing services to the public ' +
+      'internet inherently carries risks similar to port forwarding, such as ' +
+      'exposure to automated bots or vulnerabilities in the hosted application ' +
+      'itself.\n\n' +
+      'Funnel must also be enabled for your tailnet in the Tailscale admin ' +
+      'console and is restricted to ports 443, 8443, and 10000 only. ' +
+      'See https://tailscale.com/docs/features/tailscale-funnel#how-funnel-works',
+    default: 'serve' as 'serve' | 'funnel',
+    values: {
+      serve: 'Tailscale Serve (tailnet-only, any port)',
+      funnel: 'Funnel (PUBLIC internet — ports 443 / 8443 / 10000 only)',
+    },
+  }),
   port: Value.number({
     name: 'Tailnet Port',
     description:
-      'Port to expose on your Tailscale network. Leave blank to auto-assign.',
+      'Port to expose on your Tailscale network. For Funnel, must be 443, 8443, or 10000. ' +
+      'Leave blank to auto-assign.',
     required: false,
     default: null,
     integer: true,
@@ -35,8 +71,13 @@ export const addServe = sdk.Action.withInput(
   // metadata
   async () => ({
     name: 'Add Serve',
-    description: 'Expose this interface on your Tailscale network via tailscale serve',
-    warning: null,
+    description:
+      'Expose this interface on your Tailscale network via Tailscale Serve or Funnel.',
+    warning:
+      'Tailscale Serve is tailnet-only. ' +
+      'If you select Funnel mode this service will be visible to anyone on the ' +
+      'public internet — not just your tailnet. ' +
+      FUNNEL_WARNING,
     allowedStatuses: 'only-running',
     group: null,
     visibility: 'hidden',
@@ -53,6 +94,8 @@ export const addServe = sdk.Action.withInput(
     const { packageId: rawPkgId, interfaceId, hostId, internalPort } =
       input.urlPluginMetadata
     const packageId = rawPkgId ?? 'startos'
+    const mode: 'serve' | 'funnel' = input.mode ?? 'serve'
+
     // Use .once() to avoid "write after const" error
     const storeData = (await storeJson.read().once()) ?? {
       machineName: 'startos',
@@ -65,15 +108,9 @@ export const addServe = sdk.Action.withInput(
     const existing = serves[packageId]?.[interfaceId]
 
     console.info(
-      `[addServe] ${packageId}/${interfaceId} existing:`,
+      `[addServe] ${packageId}/${interfaceId} mode=${mode} existing:`,
       JSON.stringify(existing ?? null),
     )
-
-    // No early-return for already-configured entries — re-running add-serve
-    // always re-applies the serve so that entries lost (e.g. after
-    // uninstall/reinstall or manual `tailscale serve reset`) are restored.
-    // The port is preserved from the existing entry unless the user supplies
-    // a new one.
 
     // Resolve scheme and internal port from the service interface.
     // StarOS itself has no registered service interface; its UI is always
@@ -103,43 +140,75 @@ export const addServe = sdk.Action.withInput(
       resolvedInternalPort = iface?.addressInfo?.internalPort ?? internalPort
     }
 
-    console.info(
-      `[addServe] ${packageId}/${interfaceId} resolved → scheme=${scheme}, internalPort=${resolvedInternalPort}, tailnetPort=${existing !== undefined ? existing.port : '(new)'}`,
-    )
-
-    // Determine tailnet port:
-    //   1. User supplied a port: validate it, then use it (even for existing entries).
-    //   2. Existing fully-configured entry and no port supplied: preserve stored port.
-    //   3. Legacy entry (hostId === '') or new entry, no port: auto-assign.
+    // Determine tailnet port — logic differs by mode.
     let port: number
-    if (input.port !== null && input.port !== undefined) {
-      // Exclude the existing entry's own port from the "in use" check so the
-      // user can re-submit without being blocked by their own port.
-      const servesWithoutThis = {
-        ...serves,
-        [packageId]: { ...(serves[packageId] ?? {}) },
-      }
-      delete servesWithoutThis[packageId][interfaceId]
-      if (!isPortAvailable(servesWithoutThis, input.port)) {
-        const blocked = [...BLOCKED_PORTS].join(', ')
-        throw new Error(
-          `Port ${input.port} is reserved or already in use. ` +
-          `Blocked ports: ${blocked}. Choose a different port or leave blank to auto-assign.`,
+
+    if (mode === 'funnel') {
+      // ── Funnel port resolution ──────────────────────────────────────────
+      // Funnel only permits ports 443, 8443, and 10000.
+      if (input.port !== null && input.port !== undefined) {
+        assertFunnelPort(input.port)
+        // Check for conflicts against other entries (excluding this one).
+        const servesWithoutThis = {
+          ...serves,
+          [packageId]: { ...(serves[packageId] ?? {}) },
+        }
+        delete servesWithoutThis[packageId][interfaceId]
+        const allOtherPorts = Object.values(servesWithoutThis).flatMap(
+          (ifaces) => Object.values(ifaces).map((e) => e.port),
         )
+        if (allOtherPorts.includes(input.port)) {
+          throw new Error(
+            `Port ${input.port} is already in use by another serve entry. ` +
+            `Remove the existing entry first or choose a different Funnel port ` +
+            `(${FUNNEL_ALLOWED_PORTS.join(', ')}).`,
+          )
+        }
+        port = input.port
+      } else if (existing !== undefined && existing.mode === 'funnel' && existing.hostId !== '') {
+        // Preserve the stored funnel port for fully-configured existing entries.
+        port = existing.port
+      } else {
+        // Auto-assign the first free funnel port: 443 → 8443 → 10000.
+        port = assignFunnelPort(serves)
       }
-      port = input.port
-    } else if (existing !== undefined && existing.hostId !== '') {
-      // Preserve the stored port for fully-configured existing entries.
-      port = existing.port
     } else {
-      port = assignPort(serves)
+      // ── Serve port resolution (existing logic) ──────────────────────────
+      if (input.port !== null && input.port !== undefined) {
+        // Exclude the existing entry's own port from the "in use" check so the
+        // user can re-submit without being blocked by their own port.
+        const servesWithoutThis = {
+          ...serves,
+          [packageId]: { ...(serves[packageId] ?? {}) },
+        }
+        delete servesWithoutThis[packageId][interfaceId]
+        if (!isPortAvailable(servesWithoutThis, input.port)) {
+          const blocked = [...BLOCKED_PORTS].join(', ')
+          throw new Error(
+            `Port ${input.port} is reserved or already in use. ` +
+            `Blocked ports: ${blocked}. Choose a different port or leave blank to auto-assign.`,
+          )
+        }
+        port = input.port
+      } else if (existing !== undefined && existing.hostId !== '' && existing.mode !== 'funnel') {
+        // Preserve the stored port for fully-configured existing serve entries.
+        port = existing.port
+      } else {
+        port = assignPort(serves)
+      }
     }
+
+    console.info(
+      `[addServe] ${packageId}/${interfaceId} resolved → mode=${mode}, scheme=${scheme}, ` +
+      `internalPort=${resolvedInternalPort}, port=${port}`,
+    )
 
     const entry = {
       port,
       hostId,
       scheme,
       internalPort: resolvedInternalPort,
+      mode,
     }
 
     const updatedServes: z.infer<typeof servesShape> = {
@@ -165,5 +234,21 @@ export const addServe = sdk.Action.withInput(
     )
 
     await storeJson.write(effects, { ...storeData, serves: updatedServes })
+
+    // ── Result message ─────────────────────────────────────────────────────
+    // Layer 3 warning: shown only when the user confirmed Funnel mode.
+    if (mode === 'funnel') {
+      return {
+        version: '1' as const,
+        title: 'Funnel Added',
+        message:
+          `This service is now publicly accessible on the internet via Tailscale ` +
+          `Funnel on port ${port}. ` +
+          FUNNEL_WARNING +
+          ' To remove public access, click the Tailscale icon on this service\'s ' +
+          'URL row and choose Remove Serve.',
+        result: null,
+      }
+    }
   },
 )

--- a/startos/actions/addServe.ts
+++ b/startos/actions/addServe.ts
@@ -14,12 +14,10 @@ import { z } from '@start9labs/start-sdk'
 const STATE_DIR = '/var/lib/tailscale'
 
 const FUNNEL_WARNING =
-  'While Tailscale aims to preserve privacy, exposing services to the ' +
-  'public internet inherently carries risks similar to port forwarding, ' +
-  'such as exposure to automated bots or vulnerabilities in the hosted ' +
-  'application itself. ' +
-  'Learn how Funnel works before proceeding: ' +
-  'https://tailscale.com/docs/features/tailscale-funnel#how-funnel-works'
+  'While Serve stays private to your tailnet, Funnel makes your service public. ' +
+  'Exposing apps to the open internet carries inherent security risks, opening ' +
+  'them up to bot traffic and public vulnerabilities. ' +
+  'See https://tailscale.com/docs/features/tailscale-funnel for details.'
 
 const { InputSpec, Value } = sdk
 
@@ -33,17 +31,12 @@ const inputSpec = InputSpec.of({
   mode: Value.select({
     name: 'Serve Mode',
     description:
-      'Tailscale Serve shares this interface only within your private tailnet. ' +
-      'Funnel publishes it on the PUBLIC INTERNET under your node\'s MagicDNS ' +
-      'name — Tailscale manages the TLS certificate, but anyone on the internet ' +
-      'can reach the service.\n\n' +
-      'While Tailscale aims to preserve privacy, exposing services to the public ' +
-      'internet inherently carries risks similar to port forwarding, such as ' +
-      'exposure to automated bots or vulnerabilities in the hosted application ' +
-      'itself.\n\n' +
-      'Funnel must also be enabled for your tailnet in the Tailscale admin ' +
-      'console and is restricted to ports 443, 8443, and 10000 only. ' +
-      'See https://tailscale.com/docs/features/tailscale-funnel#how-funnel-works',
+      'While Serve stays private to your tailnet, Funnel makes your service public. ' +
+      'Exposing apps to the open internet carries inherent security risks, opening ' +
+      'them up to bot traffic and public vulnerabilities. ' +
+      'See https://tailscale.com/docs/features/tailscale-funnel for details.\n\n' +
+      'Funnel must be enabled for your tailnet in the Tailscale admin console ' +
+      'and is restricted to ports 443, 8443, and 10000 only.',
     default: 'serve' as 'serve' | 'funnel',
     values: {
       serve: 'Tailscale Serve (tailnet-only, any port)',

--- a/startos/actions/addServe.ts
+++ b/startos/actions/addServe.ts
@@ -235,11 +235,7 @@ export const addServe = sdk.Action.withInput(
         version: '1' as const,
         title: 'Funnel Added',
         message:
-          `This service is now publicly accessible on the internet via Tailscale ` +
-          `Funnel on port ${port}. ` +
-          FUNNEL_WARNING +
-          ' To remove public access, click the Tailscale icon on this service\'s ' +
-          'URL row and choose Remove Serve.',
+          `This service is now publicly accessible on the internet via Tailscale Funnel on port ${port}.`,
         result: null,
       }
     }

--- a/startos/fileModels/store.json.ts
+++ b/startos/fileModels/store.json.ts
@@ -30,6 +30,13 @@ export const storeEntry = z.object({
   scheme: z.string().nullable(),
   /** Port the upstream service listens on.  0 on legacy entries. */
   internalPort: z.number().int().min(0).max(65535),
+  /**
+   * Serve mode:
+   *   'serve'  → tailscale serve (tailnet-only)
+   *   'funnel' → tailscale funnel (public internet, ports 443/8443/10000 only)
+   * Defaults to 'serve' so existing entries without this field parse cleanly.
+   */
+  mode: z.enum(['serve', 'funnel']).default('serve'),
 })
 
 export type StoreEntry = z.infer<typeof storeEntry>
@@ -40,6 +47,7 @@ const legacySentinel = (port: number): StoreEntry => ({
   hostId: '',
   scheme: null,
   internalPort: 0,
+  mode: 'serve',
 })
 
 /** Shape of the serves sub-map: { [packageId]: { [interfaceId]: StoreEntry } } */

--- a/startos/plugin/url.ts
+++ b/startos/plugin/url.ts
@@ -27,6 +27,7 @@ export const exportUrls = sdk.plugin.url.setupExportedUrls(
       port: number
       hostId: string
       scheme: string | null
+      mode: 'serve' | 'funnel'
     }> = []
 
     for (const [packageId, ifaces] of Object.entries(storeData.serves)) {
@@ -42,6 +43,7 @@ export const exportUrls = sdk.plugin.url.setupExportedUrls(
           port: entry.port,
           hostId: entry.hostId,
           scheme: entry.scheme,
+          mode: entry.mode,
         })
       }
     }
@@ -49,7 +51,7 @@ export const exportUrls = sdk.plugin.url.setupExportedUrls(
     // Resolve live internalPort for each entry in parallel (Fix B).
     // Using .once() per interface avoids stacking live subscriptions (Fix C).
     await Promise.all(
-      candidates.map(async ({ packageId, interfaceId, port, hostId, scheme }) => {
+      candidates.map(async ({ packageId, interfaceId, port, hostId, scheme, mode }) => {
         let internalPort: number
 
         if (packageId === 'startos') {
@@ -87,6 +89,9 @@ export const exportUrls = sdk.plugin.url.setupExportedUrls(
         // upstream SDK/platform change to add a TCP label before reworking
         // this.
         const ssl = scheme === 'http' || scheme === 'ws' || scheme === 'https' || scheme === 'wss'
+        // Only Funnel entries are truly public (internet-accessible).
+        // Serve entries stay within the private tailnet.
+        const isPublic = mode === 'funnel'
 
         await sdk.plugin.url
           .exportUrl(effects, {
@@ -97,7 +102,7 @@ export const exportUrls = sdk.plugin.url.setupExportedUrls(
               hostId,
               internalPort,
               ssl,
-              public: true,
+              public: isPublic,
               hostname: status.dnsName,
               port,
               info: null,

--- a/startos/serves.ts
+++ b/startos/serves.ts
@@ -140,8 +140,9 @@ export async function applyServicesConfig(
 
       const result = await sub.exec(cmd)
       if (result.exitCode !== 0) {
+        const subcommand = mode === 'funnel' ? 'funnel' : 'serve'
         throw new Error(
-          `tailscale serve failed for ${packageId}/${interfaceId}: ${result.stderr.toString()}`,
+          `tailscale ${subcommand} failed for ${packageId}/${interfaceId}: ${result.stderr.toString()}`,
         )
       }
       count++

--- a/startos/serves.ts
+++ b/startos/serves.ts
@@ -44,6 +44,24 @@ export async function applyServicesConfig(
     )
   }
 
+  // Funnel state is stored separately from serve state in tailscaled —
+  // `serve reset` alone leaves previous funnel routes active.
+  // Reset funnel explicitly; this is a no-op when no funnel routes exist.
+  const funnelResetResult = await sub.exec([
+    'tailscale',
+    '--socket=' + SOCKET,
+    'funnel',
+    'reset',
+  ])
+  if (funnelResetResult.exitCode !== 0) {
+    // Log but don't throw — funnel reset fails on nodes where Funnel is not
+    // enabled in the tailnet admin console, which is a normal configuration.
+    console.warn(
+      `[serves] tailscale funnel reset exited ${funnelResetResult.exitCode}: ` +
+      funnelResetResult.stderr.toString().trim(),
+    )
+  }
+
   let count = 0
   for (const [packageId, ifaces] of Object.entries(store)) {
     for (const [interfaceId, entry] of Object.entries(ifaces)) {
@@ -55,48 +73,70 @@ export async function applyServicesConfig(
         continue
       }
 
-      const { port, scheme, internalPort } = entry
+      const { port, scheme, internalPort, mode } = entry
       // StarOS UI is reachable at 'startos'; other services use '<packageId>.startos'
       const host = packageId === 'startos' ? 'startos' : `${packageId}.startos`
 
-      let target: string
-      let isHttpProxy: boolean
+      let cmd: string[]
 
-      if (scheme === 'http' || scheme === 'ws') {
-        target = `http://${host}:${internalPort}`
-        isHttpProxy = true
-      } else if (scheme === 'https' || scheme === 'wss') {
-        target = `https+insecure://${host}:${internalPort}`
-        isHttpProxy = true
+      if (mode === 'funnel') {
+        // Funnel: Tailscale terminates TLS externally and proxies to an HTTP
+        // backend. Always use plain http:// as the target regardless of the
+        // upstream scheme — the node-facing side is always plain HTTP.
+        // External port must be 443, 8443, or 10000 (enforced at add-time too).
+        const funnelTarget = `http://${host}:${internalPort}`
+        console.info(
+          `[serves] ${packageId}/${interfaceId}: funnel --https=${port} ${funnelTarget}`,
+        )
+        cmd = [
+          'tailscale',
+          '--socket=' + SOCKET,
+          'funnel',
+          '--bg',
+          `--https=${port}`,
+          funnelTarget,
+        ]
       } else {
-        // TCP passthrough: null, 'ssh', 'dns', or any unrecognised scheme
-        target = `tcp://${host}:${internalPort}`
-        isHttpProxy = false
+        // Regular serve: http proxy vs tcp passthrough based on upstream scheme.
+        let target: string
+        let isHttpProxy: boolean
+
+        if (scheme === 'http' || scheme === 'ws') {
+          target = `http://${host}:${internalPort}`
+          isHttpProxy = true
+        } else if (scheme === 'https' || scheme === 'wss') {
+          target = `https+insecure://${host}:${internalPort}`
+          isHttpProxy = true
+        } else {
+          // TCP passthrough: null, 'ssh', 'dns', or any unrecognised scheme
+          target = `tcp://${host}:${internalPort}`
+          isHttpProxy = false
+        }
+
+        console.info(
+          `[serves] ${packageId}/${interfaceId}: scheme=${scheme} → ${isHttpProxy ? '--https' : '--tcp'} ${port} ${target}`,
+        )
+
+        cmd = isHttpProxy
+          ? [
+              'tailscale',
+              '--socket=' + SOCKET,
+              'serve',
+              '--bg',
+              '--https',
+              String(port),
+              target,
+            ]
+          : [
+              'tailscale',
+              '--socket=' + SOCKET,
+              'serve',
+              '--bg',
+              '--tcp',
+              String(port),
+              target,
+            ]
       }
-
-      console.info(
-        `[serves] ${packageId}/${interfaceId}: scheme=${scheme} → ${isHttpProxy ? '--https' : '--tcp'} ${port} ${target}`,
-      )
-
-      const cmd = isHttpProxy
-        ? [
-            'tailscale',
-            '--socket=' + SOCKET,
-            'serve',
-            '--bg',
-            '--https',
-            String(port),
-            target,
-          ]
-        : [
-            'tailscale',
-            '--socket=' + SOCKET,
-            'serve',
-            '--bg',
-            '--tcp',
-            String(port),
-            target,
-          ]
 
       const result = await sub.exec(cmd)
       if (result.exitCode !== 0) {

--- a/startos/utils.ts
+++ b/startos/utils.ts
@@ -7,8 +7,45 @@ import { UI_PORT } from './constants'
  * These cannot be used for serve entries.
  *  - 80, 443: reserved by Tailscale for HTTP/HTTPS on the tailnet
  *  - UI_PORT (8080): the Tailscale web UI
+ *
+ * NOTE: port 443 is blocked for regular serve entries but IS valid for
+ * Funnel. The funnel code path uses assertFunnelPort() / assignFunnelPort()
+ * instead of isPortAvailable() so it never hits this set.
  */
 export const BLOCKED_PORTS = new Set([80, 443, UI_PORT])
+
+/** The only external ports Tailscale Funnel accepts. */
+export const FUNNEL_ALLOWED_PORTS = [443, 8443, 10000] as const
+
+/**
+ * Throws a user-facing error if port is not a valid Tailscale Funnel port.
+ */
+export function assertFunnelPort(port: number): void {
+  if (!(FUNNEL_ALLOWED_PORTS as readonly number[]).includes(port)) {
+    throw new Error(
+      `Funnel only accepts ports ${FUNNEL_ALLOWED_PORTS.join(', ')}. ` +
+      `Choose one of those or switch to Tailscale Serve mode.`,
+    )
+  }
+}
+
+/**
+ * Returns the first unused Tailscale Funnel port from [443, 8443, 10000].
+ * Throws if all three are already assigned to existing entries.
+ */
+export function assignFunnelPort(store: z.infer<typeof servesShape>): number {
+  const allPorts = Object.values(store).flatMap((ifaces) =>
+    Object.values(ifaces).map((e) => e.port),
+  )
+  const used = new Set(allPorts)
+  for (const p of FUNNEL_ALLOWED_PORTS) {
+    if (!used.has(p)) return p
+  }
+  throw new Error(
+    `All Funnel ports (${FUNNEL_ALLOWED_PORTS.join(', ')}) are already in use. ` +
+    `Remove an existing Funnel entry before adding another.`,
+  )
+}
 
 /**
  * Assigns the next available Tailscale serve port.


### PR DESCRIPTION
Closes #27

## What

Adds **Tailscale Funnel** as a selectable mode alongside Tailscale Serve in the URL-plugin `add-serve` action. Funnel publishes a StartOS service interface on the **public internet** (not just the tailnet) under the node's MagicDNS name, with Tailscale managing TLS.

## Files changed (5)

| File | Change |
|---|---|
| `startos/utils.ts` | Add `FUNNEL_ALLOWED_PORTS`, `assertFunnelPort()`, `assignFunnelPort()` |
| `startos/fileModels/store.json.ts` | Add `mode: z.enum(['serve','funnel']).default('serve')` to `storeEntry` |
| `startos/serves.ts` | Run `tailscale funnel reset` alongside `tailscale serve reset`; branch on `entry.mode` to call `tailscale funnel --bg --https=<port>` for funnel entries |
| `startos/actions/addServe.ts` | Add mode selector with three-layer warning; funnel port validation (443/8443/10000) and auto-assignment |
| `startos/plugin/url.ts` | Set `public: mode === 'funnel'` (fixes hardcoded `true`); propagate `mode` through candidates |

## Backward compatibility

All existing `store.json` entries without a `mode` field parse as `'serve'` via Zod's `.default('serve')` — no migration, no breaking change.

## Three-layer warning in the UI

Funnel surfaces a warning at every stage before and after the route is saved:

1. **Action banner** (always shown on open, regardless of mode) — flags that Funnel = public internet + doc link
2. **Mode select field description** (persistent inline text) — full risk explanation including the user's exact wording, port restriction, admin console requirement, and doc link
3. **Post-execution result message** (only shown after confirming Funnel) — reiterates the risk with the doc link and a removal tip

Risk text used throughout:
> While Tailscale aims to preserve privacy, exposing services to the public internet inherently carries risks similar to port forwarding, such as exposure to automated bots or vulnerabilities in the hosted application itself.

Doc link: https://tailscale.com/docs/features/tailscale-funnel#how-funnel-works

## What is NOT included (no Go proxy needed)

The tobomobo reference implementation uses a Go proxy binary to route through `127.0.0.1:localPort`. That's not needed here — `tailscale-startos` already points serve targets at `packageId.startos:internalPort`, which tailscaled resolves directly in `--tun=userspace-networking` mode. Funnel uses the same serve backend, so the same direct-target approach works.