### PR TITLE
feat(actions): add Logout action

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,13 @@ tailscale-startos/
 │   ├── main.ts               # Daemon definitions, health checks, serve restoration
 │   ├── sdk.ts                # Package-specific SDK instance
 │   ├── constants.ts          # UI_PORT = 8080
-│   ├── utils.ts              # assignPort, isPortAvailable, parseTailscaleIp, parseDnsName
+│   ├── utils.ts              # assignPort, isPortAvailable, parseTailscaleIp, parseDnsName, isSocketUnavailableError
 │   ├── serves.ts             # applyServicesConfig() — reset and reapply all serves
 │   ├── actions/
 │   │   ├── index.ts          # Actions.of() registration
+│   │   ├── login.ts          # Login action (headless auth key or web UI)
+│   │   ├── setMachineName.ts # Set Machine Name action (hostname / MagicDNS)
+│   │   ├── logout.ts         # Logout action (log out of tailnet + clear state)
 │   │   ├── addServe.ts       # Add Serve action (URL plugin table action)
 │   │   └── removeServe.ts    # Remove Serve action (URL plugin table action)
 │   ├── plugin/

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ All Tailscale configuration is managed through the **Tailscale web interface**
 | Subnet router       | Web UI → Settings → Subnet router         |
 | Exit node           | Web UI → This device → Exit node          |
 | Tailscale SSH       | Web UI → Settings → Tailscale SSH server  |
-| Logout / re-auth    | Web UI → Settings → Log out               |
+| Logout / re-auth    | **Logout** action (Actions panel), or Web UI → Settings → Log out |
 | Expose services     | URL plugin → Add Serve (tile action, choose Serve or Funnel mode) |
 
 ### Daemon environment
@@ -200,6 +200,25 @@ Auth keys expire after 1–90 days (default 90). After expiry, the authenticated
 node remains connected until its node key expires (default 180 days). See the
 [Tailscale auth key docs](https://tailscale.com/docs/features/access-control/auth-keys)
 for details on reusable, ephemeral, pre-approved, and tagged keys.
+
+### Logout
+
+Visible in the Actions panel. **Requires the service to be running.**
+
+Logs this node out of Tailscale, notifying the control plane so the node is
+removed from the tailnet and the admin console. After logout the node enters
+`NeedsLogin` state — use the **Login** action to re-authenticate.
+
+> **Note:** The service must be running when you invoke this action. Logout
+> requires a round-trip to the Tailscale control plane; if the daemon socket is
+> unreachable a clear error is returned rather than silently wiping local state.
+
+**What it does internally:**
+
+1. Runs `tailscale logout` against the running daemon via a shared temp subcontainer.
+2. Clears any staged `authKey` from `store.json` (so a saved key is not re-applied on the next start).
+3. Clears the cached `{ ip, dnsName }` from `status.json` (stale once the node leaves the tailnet).
+4. Returns a confirmation modal: _"This node has been logged out of Tailscale and removed from your tailnet."_
 
 ### Add Serve / Remove Serve
 
@@ -420,4 +439,14 @@ actions:
         ready-check detects BackendState=NeedsLogin and runs tailscale login --auth-key=<key>
         clears authKey from store once BackendState=Running
       if authKey blank: return immediately (user logs in via web UI)
+  - id: logout   # visible in the Actions panel
+    name: Logout
+    description: Log this node out of Tailscale; requires the service to be running (control-plane round-trip)
+    input: none
+    behavior: |
+      tailscale logout via shared temp subcontainer (requires daemon socket)
+      on success:
+        clear authKey from startos/store.json
+        clear ip + dnsName from startos/status.json
+      if socket unavailable: surface friendly error — start service first
 ```

--- a/startos/actions/disconnect.ts
+++ b/startos/actions/disconnect.ts
@@ -1,0 +1,133 @@
+import { sdk } from '../sdk'
+import { statusJson } from '../fileModels/status.json'
+import { storeJson } from '../fileModels/store.json'
+
+const STATE_DIR = '/var/lib/tailscale'
+const SOCKET = '/var/run/tailscale/tailscaled.sock'
+
+export const disconnect = sdk.Action.withoutInput(
+  // id
+  'disconnect',
+
+  // metadata
+  async () => ({
+    name: 'Disconnect / Reset',
+    description:
+      'Log out of Tailscale, remove this node from your tailnet, and clear ' +
+      'all persisted auth state. Use the Login action to reconnect with a new auth key.',
+    warning:
+      'This will immediately remove this node from your Tailscale network. ' +
+      'You will need to re-authenticate to reconnect.',
+    allowedStatuses: 'any' as const,
+    group: 'Tailscale',
+    visibility: 'enabled' as const,
+  }),
+
+  // execution
+  async ({ effects }) => {
+    const mounts = sdk.Mounts.of().mountVolume({
+      volumeId: 'tailscale',
+      subpath: null,
+      mountpoint: STATE_DIR,
+      readonly: false,
+    })
+
+    // Attempt `tailscale logout` against the running daemon.  If the socket is
+    // unavailable (service stopped) we surface a clear error rather than
+    // silently wiping local state — logout requires a round-trip to the
+    // Tailscale control plane to actually expire the session and remove the
+    // node from the admin console.
+    try {
+      await sdk.SubContainer.withTemp(
+        effects,
+        { imageId: 'tailscale', sharedRun: true },
+        mounts,
+        'tailscale-disconnect',
+        async (sub) => {
+          const result = await sub.exec([
+            'tailscale',
+            '--socket=' + SOCKET,
+            'logout',
+          ])
+
+          if (result.exitCode !== 0) {
+            const stderr = result.stderr?.toString().trim() ?? ''
+            const stdout = result.stdout?.toString().trim() ?? ''
+            const errText = stderr || stdout || `exit code ${result.exitCode}`
+
+            // Detect socket-unavailable errors and surface a helpful message.
+            const isSocketError =
+              errText.includes('no such file') ||
+              errText.includes('ENOENT') ||
+              errText.includes('ECONNREFUSED') ||
+              errText.includes('connect: connection refused') ||
+              errText.includes('connect: no such file')
+
+            if (isSocketError) {
+              throw new Error(
+                'Tailscale daemon is not running. ' +
+                  'Start the service first, then use Disconnect / Reset to log out.',
+              )
+            }
+
+            throw new Error('tailscale logout failed: ' + errText)
+          }
+
+          console.info('[disconnect] tailscale logout succeeded.')
+        },
+      )
+    } catch (err) {
+      const msg = String(err)
+
+      // Re-classify raw socket errors that bubble up before exec() returns
+      // (e.g. the subcontainer itself cannot connect to the shared socket).
+      const isSocketError =
+        msg.includes('no such file') ||
+        msg.includes('ENOENT') ||
+        msg.includes('ECONNREFUSED') ||
+        msg.includes('connect: connection refused') ||
+        msg.includes('connect: no such file')
+
+      if (isSocketError) {
+        throw new Error(
+          'Tailscale daemon is not running. ' +
+            'Start the service first, then use Disconnect / Reset to log out.',
+        )
+      }
+
+      throw err
+    }
+
+    // Logout succeeded — clean up local state that is now stale.
+
+    // Clear any staged auth key so it is not applied on the next start
+    // (the user must explicitly provide a new key via the Login action).
+    try {
+      const store = await storeJson.read().once()
+      if (store?.authKey) {
+        await storeJson.write(effects, { ...store, authKey: null })
+        console.info('[disconnect] Cleared staged auth key from store.json.')
+      }
+    } catch (e) {
+      console.warn('[disconnect] Could not clear auth key from store.json:', e)
+    }
+
+    // Clear the cached IP/DNS — they are no longer valid once the node is
+    // removed from the tailnet.
+    try {
+      await statusJson.write(effects, { ip: '', dnsName: '' })
+      console.info('[disconnect] Cleared status.json.')
+    } catch (e) {
+      console.warn('[disconnect] Could not clear status.json:', e)
+    }
+
+    return {
+      version: '1' as const,
+      title: 'Disconnected',
+      message:
+        'This node has been logged out of Tailscale and removed from your tailnet. ' +
+        'Use the Login action to reconnect with a new auth key.',
+      result: null,
+    }
+  },
+)

--- a/startos/actions/disconnect.ts
+++ b/startos/actions/disconnect.ts
@@ -11,7 +11,7 @@ export const disconnect = sdk.Action.withoutInput(
 
   // metadata
   async () => ({
-    name: 'Disconnect / Reset',
+    name: 'Logout',
     description:
       'Log out of Tailscale, remove this node from your tailnet, and clear ' +
       'all persisted auth state. Use the Login action to reconnect with a new auth key.',
@@ -66,7 +66,7 @@ export const disconnect = sdk.Action.withoutInput(
             if (isSocketError) {
               throw new Error(
                 'Tailscale daemon is not running. ' +
-                  'Start the service first, then use Disconnect / Reset to log out.',
+                  'Start the service first, then use Logout to log out.',
               )
             }
 
@@ -91,7 +91,7 @@ export const disconnect = sdk.Action.withoutInput(
       if (isSocketError) {
         throw new Error(
           'Tailscale daemon is not running. ' +
-            'Start the service first, then use Disconnect / Reset to log out.',
+            'Start the service first, then use Logout to log out.',
         )
       }
 

--- a/startos/actions/index.ts
+++ b/startos/actions/index.ts
@@ -1,6 +1,6 @@
 import { sdk } from '../sdk'
 import { addServe } from './addServe'
-import { disconnect } from './disconnect'
+import { logout } from './logout'
 import { getStarted } from './login'
 import { removeServe } from './removeServe'
 import { setMachineName } from './setMachineName'
@@ -8,6 +8,6 @@ import { setMachineName } from './setMachineName'
 export const actions = sdk.Actions.of()
   .addAction(setMachineName)
   .addAction(getStarted)
-  .addAction(disconnect)
+  .addAction(logout)
   .addAction(addServe)
   .addAction(removeServe)

--- a/startos/actions/index.ts
+++ b/startos/actions/index.ts
@@ -1,5 +1,6 @@
 import { sdk } from '../sdk'
 import { addServe } from './addServe'
+import { disconnect } from './disconnect'
 import { getStarted } from './login'
 import { removeServe } from './removeServe'
 import { setMachineName } from './setMachineName'
@@ -7,5 +8,6 @@ import { setMachineName } from './setMachineName'
 export const actions = sdk.Actions.of()
   .addAction(setMachineName)
   .addAction(getStarted)
+  .addAction(disconnect)
   .addAction(addServe)
   .addAction(removeServe)

--- a/startos/actions/logout.ts
+++ b/startos/actions/logout.ts
@@ -1,13 +1,14 @@
 import { sdk } from '../sdk'
 import { statusJson } from '../fileModels/status.json'
 import { storeJson } from '../fileModels/store.json'
+import { isSocketUnavailableError } from '../utils'
 
 const STATE_DIR = '/var/lib/tailscale'
 const SOCKET = '/var/run/tailscale/tailscaled.sock'
 
-export const disconnect = sdk.Action.withoutInput(
+export const logout = sdk.Action.withoutInput(
   // id
-  'disconnect',
+  'logout',
 
   // metadata
   async () => ({
@@ -42,7 +43,7 @@ export const disconnect = sdk.Action.withoutInput(
         effects,
         { imageId: 'tailscale', sharedRun: true },
         mounts,
-        'tailscale-disconnect',
+        'tailscale-logout',
         async (sub) => {
           const result = await sub.exec([
             'tailscale',
@@ -56,14 +57,7 @@ export const disconnect = sdk.Action.withoutInput(
             const errText = stderr || stdout || `exit code ${result.exitCode}`
 
             // Detect socket-unavailable errors and surface a helpful message.
-            const isSocketError =
-              errText.includes('no such file') ||
-              errText.includes('ENOENT') ||
-              errText.includes('ECONNREFUSED') ||
-              errText.includes('connect: connection refused') ||
-              errText.includes('connect: no such file')
-
-            if (isSocketError) {
+            if (isSocketUnavailableError(errText)) {
               throw new Error(
                 'Tailscale daemon is not running. ' +
                   'Start the service first, then use Logout to log out.',
@@ -73,7 +67,7 @@ export const disconnect = sdk.Action.withoutInput(
             throw new Error('tailscale logout failed: ' + errText)
           }
 
-          console.info('[disconnect] tailscale logout succeeded.')
+          console.info('[logout] tailscale logout succeeded.')
         },
       )
     } catch (err) {
@@ -81,14 +75,7 @@ export const disconnect = sdk.Action.withoutInput(
 
       // Re-classify raw socket errors that bubble up before exec() returns
       // (e.g. the subcontainer itself cannot connect to the shared socket).
-      const isSocketError =
-        msg.includes('no such file') ||
-        msg.includes('ENOENT') ||
-        msg.includes('ECONNREFUSED') ||
-        msg.includes('connect: connection refused') ||
-        msg.includes('connect: no such file')
-
-      if (isSocketError) {
+      if (isSocketUnavailableError(msg)) {
         throw new Error(
           'Tailscale daemon is not running. ' +
             'Start the service first, then use Logout to log out.',
@@ -106,19 +93,19 @@ export const disconnect = sdk.Action.withoutInput(
       const store = await storeJson.read().once()
       if (store?.authKey) {
         await storeJson.write(effects, { ...store, authKey: null })
-        console.info('[disconnect] Cleared staged auth key from store.json.')
+        console.info('[logout] Cleared staged auth key from store.json.')
       }
     } catch (e) {
-      console.warn('[disconnect] Could not clear auth key from store.json:', e)
+      console.warn('[logout] Could not clear auth key from store.json:', e)
     }
 
     // Clear the cached IP/DNS — they are no longer valid once the node is
     // removed from the tailnet.
     try {
       await statusJson.write(effects, { ip: '', dnsName: '' })
-      console.info('[disconnect] Cleared status.json.')
+      console.info('[logout] Cleared status.json.')
     } catch (e) {
-      console.warn('[disconnect] Could not clear status.json:', e)
+      console.warn('[logout] Could not clear status.json:', e)
     }
 
     return {

--- a/startos/utils.ts
+++ b/startos/utils.ts
@@ -75,6 +75,23 @@ export function isPortAvailable(
 }
 
 /**
+ * Returns true if the error message indicates the tailscaled socket is
+ * unavailable (service stopped, container not running, etc.).
+ *
+ * Matches the same broad set of patterns used in login.ts so that any
+ * socket-related message is classified consistently across all actions.
+ */
+export function isSocketUnavailableError(msg: string): boolean {
+  return (
+    msg.includes('no such file') ||
+    msg.includes('ENOENT') ||
+    msg.includes('ECONNREFUSED') ||
+    msg.includes('connect') ||
+    msg.includes('socket')
+  )
+}
+
+/**
  * Parses the output of `tailscale ip -4` to a trimmed IPv4 string.
  */
 export function parseTailscaleIp(stdout: string): string {


### PR DESCRIPTION
## Summary

Implements [#31](https://github.com/sudocarlos/tailscale-startos/issues/31) — a **Logout** action that logs the node out of the tailnet and clears persisted auth state.

## What it does

- Adds `startos/actions/logout.ts` — a `sdk.Action.withoutInput` action that:
  - Runs `tailscale logout` via a `sharedRun: true` temp subcontainer (requires a running daemon to talk to the Tailscale control plane)
  - On success: clears any staged `authKey` from `store.json` and invalidates the cached IP/DNS in `status.json`
  - Returns a confirmation modal: _"This node has been logged out of Tailscale…"_
  - If the daemon socket is unreachable (service stopped): surfaces a friendly error — _"Start the service first, then use Logout to log out"_ — rather than silently wiping local state
- Extracts `isSocketUnavailableError()` into `utils.ts`, aligning the socket-error predicate breadth with `login.ts` (previously the inline checks in the action used narrower strings)
- Registers the action in `startos/actions/index.ts` between Login and the serve table actions
- Documents the Logout action in `README.md` (configuration table, Actions section, AI Quick Reference)
- Updates `CONTRIBUTING.md` layout table with `logout.ts` and `utils.ts` additions

## After logout

The node enters `NeedsLogin` state. The existing **Login** action handles re-authentication via auth key or interactive web UI — no additional changes needed.

closes #31