### PR TITLE
feat: bump Tailscale to v1.98.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: 'Tag name of the release to build and upload (e.g. v1.98.4-0)'
+        description: 'Tag name of the release to build and upload (e.g. v1.98.8-0)'
         required: true
         type: string
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ expose other StartOS services to your tailnet via `tailscale serve`, or to the p
 
 | Property      | Value                              |
 | ------------- | ---------------------------------- |
-| Image         | `ghcr.io/tailscale/tailscale:v1.98.4` |
+| Image         | `ghcr.io/tailscale/tailscale:v1.98.8` |
 | Architectures | x86_64, aarch64                    |
 | Runtime       | Two daemons in one subcontainer    |
 
@@ -323,7 +323,7 @@ None. Tailscale is a standalone service.
 4. **HTTPS reverse proxy for HTTP services** — `tailscale serve --bg --https`
    is used for HTTP backends; Tailscale terminates TLS so clients access
    services over `https://`. Non-HTTP services use raw TCP forwarding.
-5. **Web UI requires Tailscale v1.56.0+** — the `ghcr.io/tailscale/tailscale:v1.98.4`
+5. **Web UI requires Tailscale v1.56.0+** — the `ghcr.io/tailscale/tailscale:v1.98.8`
    image satisfies this requirement.
 
 ---
@@ -351,7 +351,7 @@ workflow.
 
 ```yaml
 package_id: tailscale
-image: ghcr.io/tailscale/tailscale:v1.98.4
+image: ghcr.io/tailscale/tailscale:v1.98.8
 architectures: [x86_64, aarch64]
 volumes:
   tailscale: /var/lib/tailscale       # daemon state

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -14,7 +14,7 @@ export const manifest = setupManifest({
   volumes: ['tailscale', 'startos'],
   images: {
     tailscale: {
-      source: { dockerTag: 'ghcr.io/tailscale/tailscale:v1.98.4' },
+      source: { dockerTag: 'ghcr.io/tailscale/tailscale:v1.98.8' },
       arch: ['x86_64', 'aarch64'],
     },
   },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,4 +1,5 @@
 import { VersionGraph } from '@start9labs/start-sdk'
+import { v_1_98_8_0 } from './v1.98.8.0'
 import { v_1_96_4_0 } from './v1.96.4.0'
 import { v_1_96_5_0 } from './v1.96.5.0'
 import { v_1_96_5_2 } from './v1.96.5.2'
@@ -6,6 +7,6 @@ import { v_1_96_5_3 } from './v1.96.5.3'
 import { v_1_98_4_0 } from './v1.98.4.0'
 
 export const versionGraph = VersionGraph.of({
-  current: v_1_98_4_0,
-  other: [v_1_96_5_3, v_1_96_5_2, v_1_96_5_0, v_1_96_4_0],
+  current: v_1_98_8_0,
+  other: [v_1_96_5_3, v_1_96_5_2, v_1_96_5_0, v_1_96_4_0, v_1_98_4_0],
 })

--- a/startos/versions/v1.98.8.0.ts
+++ b/startos/versions/v1.98.8.0.ts
@@ -1,0 +1,19 @@
+import { VersionInfo } from '@start9labs/start-sdk'
+
+export const v_1_98_8_0 = VersionInfo.of({
+  version: '1.98.8:0',
+  releaseNotes: {
+    en_US:
+      'Tailscale updated from v1.98.4 to v1.98.8. ' +
+      'v1.98.5 only changed Apple-platform builds (not relevant). ' +
+      'v1.98.6 and v1.98.7 were release candidates (skipped). ' +
+      'Highlights in v1.98.8: ' +
+      'fixed connectivity disruptions when the OS wakes from sleep (wireguard-go); ' +
+      'fixed excessive handshake initiation retries (wireguard-go); ' +
+      'fixed connection leaks in Tailscale SSH Session Recording.',
+  },
+  migrations: {
+    up: async ({ effects }) => {},
+    down: async ({ effects }) => {},
+  },
+})


### PR DESCRIPTION
Closes #34

## Summary

Bump the Tailscale container image from `v1.98.4` to `v1.98.8`.

### Files changed

- **`startos/manifest/index.ts`** — update dockerTag to `ghcr.io/tailscale/tailscale:v1.98.8`
- **`startos/versions/v1.98.8.0.ts`** — new version file with release notes from upstream changelog
- **`startos/versions/index.ts`** — register v1.98.8.0 as current, add v1.98.4.0 to other
- **`README.md`** — update all v1.98.4 references to v1.98.8
- **`.github/workflows/release.yml`** — update example tag in workflow description

### Release notes (v1.98.4 → v1.98.8)

- v1.98.5: Apple-platform only (not relevant)
- v1.98.6/v1.98.7: release candidates (skipped)
- v1.98.8: fixed connectivity disruptions on wake from sleep (wireguard-go); fixed excessive handshake initiation retries (wireguard-go); fixed connection leaks in Tailscale SSH Session Recording

### Verification

- `make x86` completed successfully (JS compiled, s9pk packed)
- `start-cli s9pk inspect tailscale_x86_64.s9pk manifest | jq .version` → `"1.98.8:0"`